### PR TITLE
Make NPM package public

### DIFF
--- a/.github/workflows/npm_dist.yml
+++ b/.github/workflows/npm_dist.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   publish:
-    name: Publish Package
+    name: Publish NPM Package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,6 +20,6 @@ jobs:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
       - name: Publish package on NPM
-        run: npm publish
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PASSWORD }}

--- a/.github/workflows/pypi_dist.yml
+++ b/.github/workflows/pypi_dist.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-n-publish:
-    name: Build and Publish Package
+    name: Build and Publish PyPI Package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Address the following `npm publish` error.

```
npm ERR! code E402
npm ERR! 402 Payment Required - PUT https://registry.npmjs.org/@internetarchive%2fcdxsummary - You must sign up for private packages
```
