### PR TITLE
Overhaul of the WebComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,3 +389,7 @@ $ cdxsummary --json sample.cdx.gz
 }
 ```
 </details>
+
+## Testing
+
+An [interactive test interface](https://internetarchive.github.io/cdx-summary/webcomponent/) is available for the Web Component that renders the JSON summary.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ optional arguments:
 
 ## Sample Output
 
-```
-$ cdxsummary sample.cdx.gz
+Plain text summary (with colors, when supported by the terminal):
 
+<details>
+  <summary>$ cdxsummary sample.cdx.gz</summary>
+
+```
              CDX Overview             
  ──────────────────────────────────── 
  Total Captures in CDX         74,460 
@@ -154,6 +157,12 @@ $ cdxsummary sample.cdx.gz
  * https://web.archive.org/web/20210318000510/https://roundme.com/embed/ro6VYzBNE5vePdZ3xyph
  * https://web.archive.org/web/20210318000510/https://prevention.cancer.gov/news-and-events/videos-and-webinars
 ```
+</details>
+
+JSON summary:
+
+<details>
+  <summary>$ cdxsummary --json sample.cdx.gz</summary>
 
 ```
 $ cdxsummary --json sample.cdx.gz
@@ -379,3 +388,4 @@ $ cdxsummary --json sample.cdx.gz
   ]
 }
 ```
+</details>

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ optional arguments:
 
 ## Sample Output
 
-Plain text summary (with colors, when supported by the terminal):
+### Plain Text Summary
 
 <details>
   <summary>$ cdxsummary sample.cdx.gz</summary>
@@ -159,7 +159,7 @@ Plain text summary (with colors, when supported by the terminal):
 ```
 </details>
 
-JSON summary:
+### JSON Summary
 
 <details>
   <summary>$ cdxsummary --json sample.cdx.gz</summary>

--- a/webcomponent/README.md
+++ b/webcomponent/README.md
@@ -12,13 +12,21 @@ Alternatively, render a summary from a `web` collection/item of Internet Archive
 <cdx-summary item="PETABOX_ITEM_OR_COLLECTION_ID"></cdx-summary>
 ```
 
+One of the `src` and `item` attributes is mandatory for the element to render.
+
 By default, sample capture playback links (i.e., memento URIs or URI-Ms) point to `https://web.archive.org/web/`, but this can be customized by specifying the `playback` attribute.
 To control the maximum number of thumbnails of random sample captures (rendered by embedding them in iframes), specify a positive integer in the `thumbs` attribute.
 The list of random sample capture playback URIs are hidden by default, but can be expanded by setting the `samples-drawer` attribute to `open`.
+The element accepts a `title` attribute, which defaults to the name of the summary file (without extensions).
+A `type` attribute can be used to customize textual descriptions with a value of `collection`, `item`, or `CDX` (defaults to `CDX`).
+A `report` attribute points to a comprehensive version of the summary file, which is derived from the `item` attribute for Petabox items/collections, unless specified explicitly.
 The code below illustrates the usage of these attributes.
 
 ```html
 <cdx-summary src="https://example.org/files/covid-collection-cdx.summary.json"
+             report="https://example.org/files/covid-collection-cdx.report.json.gz"
+             type="collection"
+             title="COVID-19 Collection"
              thumbs="10"
              playback="https://archive.example.com/memento/"
              samples-drawer="open">

--- a/webcomponent/README.md
+++ b/webcomponent/README.md
@@ -20,6 +20,7 @@ The list of random sample capture playback URIs are hidden by default, but can b
 The element accepts a `name` attribute, which defaults to the name of the summary file (without extensions).
 A `type` attribute can be used to customize textual descriptions with a value of `collection`, `item`, or `CDX` (defaults to `CDX`).
 A `report` attribute points to a comprehensive version of the summary file, which is derived from the `item` attribute for Petabox items/collections, unless specified explicitly.
+Number reported in various table cells can be formatted using `format` attribute with values `short`, `percent`, or `local` (defaults to `local`).
 The code below illustrates the usage of these attributes.
 
 ```html
@@ -27,6 +28,7 @@ The code below illustrates the usage of these attributes.
              report="https://example.org/files/covid-collection-cdx.report.json.gz"
              type="collection"
              name="COVID-19 Collection"
+             format="short"
              thumbs="10"
              playback="https://archive.example.com/memento/"
              samples-drawer="open">

--- a/webcomponent/README.md
+++ b/webcomponent/README.md
@@ -14,11 +14,13 @@ Alternatively, render a summary from a `web` collection/item of Internet Archive
 
 By default, sample capture playback links (i.e., memento URIs or URI-Ms) point to `https://web.archive.org/web/`, but this can be customized by specifying the `playback` attribute.
 To control the maximum number of thumbnails of random sample captures (rendered by embedding them in iframes), specify a positive integer in the `thumbs` attribute.
+The list of random sample capture playback URIs are hidden by default, but can be expanded by setting the `samples-drawer` attribute to `open`.
 The code below illustrates the usage of these attributes.
 
 ```html
 <cdx-summary src="https://example.org/files/covid-collection-cdx.summary.json"
              thumbs="10"
-             playback="https://archive.example.com/memento/">
+             playback="https://archive.example.com/memento/"
+             samples-drawer="open">
 </cdx-summary>
 ```

--- a/webcomponent/README.md
+++ b/webcomponent/README.md
@@ -34,3 +34,5 @@ The code below illustrates the usage of these attributes.
              drawer="open">
 </cdx-summary>
 ```
+
+An [interactive test interface](https://internetarchive.github.io/cdx-summary/webcomponent/) is available for the Web Component that renders the JSON summary.

--- a/webcomponent/README.md
+++ b/webcomponent/README.md
@@ -17,7 +17,7 @@ One of the `src` and `item` attributes is mandatory for the element to render.
 By default, sample capture playback links (i.e., memento URIs or URI-Ms) point to `https://web.archive.org/web/`, but this can be customized by specifying the `playback` attribute.
 To control the maximum number of thumbnails of random sample captures (rendered by embedding them in iframes), specify a positive integer in the `thumbs` attribute.
 The list of random sample capture playback URIs are hidden by default, but can be expanded by setting the `samples-drawer` attribute to `open`.
-The element accepts a `title` attribute, which defaults to the name of the summary file (without extensions).
+The element accepts a `name` attribute, which defaults to the name of the summary file (without extensions).
 A `type` attribute can be used to customize textual descriptions with a value of `collection`, `item`, or `CDX` (defaults to `CDX`).
 A `report` attribute points to a comprehensive version of the summary file, which is derived from the `item` attribute for Petabox items/collections, unless specified explicitly.
 The code below illustrates the usage of these attributes.
@@ -26,7 +26,7 @@ The code below illustrates the usage of these attributes.
 <cdx-summary src="https://example.org/files/covid-collection-cdx.summary.json"
              report="https://example.org/files/covid-collection-cdx.report.json.gz"
              type="collection"
-             title="COVID-19 Collection"
+             name="COVID-19 Collection"
              thumbs="10"
              playback="https://archive.example.com/memento/"
              samples-drawer="open">

--- a/webcomponent/README.md
+++ b/webcomponent/README.md
@@ -11,3 +11,14 @@ Alternatively, render a summary from a `web` collection/item of Internet Archive
 ```html
 <cdx-summary item="PETABOX_ITEM_OR_COLLECTION_ID"></cdx-summary>
 ```
+
+By default, sample capture playback links (i.e., memento URIs or URI-Ms) point to `https://web.archive.org/web/`, but this can be customized by specifying the `playback` attribute.
+To control the maximum number of thumbnails of random sample captures (rendered by embedding them in iframes), specify a positive integer in the `thumbs` attribute.
+The code below illustrates the usage of these attributes.
+
+```html
+<cdx-summary src="https://example.org/files/covid-collection-cdx.summary.json"
+             thumbs="10"
+             playback="https://archive.example.com/memento/">
+</cdx-summary>
+```

--- a/webcomponent/README.md
+++ b/webcomponent/README.md
@@ -16,7 +16,7 @@ One of the `src` and `item` attributes is mandatory for the element to render.
 
 By default, sample capture playback links (i.e., memento URIs or URI-Ms) point to `https://web.archive.org/web/`, but this can be customized by specifying the `playback` attribute.
 To control the maximum number of thumbnails of random sample captures (rendered by embedding them in iframes), specify a positive integer in the `thumbs` attribute.
-The list of random sample capture playback URIs are hidden by default, but can be expanded by setting the `samples-drawer` attribute to `open`.
+The list of random sample capture playback URIs are hidden by default, but can be expanded by setting the `drawer` attribute to `open`.
 The element accepts a `name` attribute, which defaults to the name of the summary file (without extensions).
 A `type` attribute can be used to customize textual descriptions with a value of `collection`, `item`, or `CDX` (defaults to `CDX`).
 A `report` attribute points to a comprehensive version of the summary file, which is derived from the `item` attribute for Petabox items/collections, unless specified explicitly.
@@ -31,6 +31,6 @@ The code below illustrates the usage of these attributes.
              format="short"
              thumbs="10"
              playback="https://archive.example.com/memento/"
-             samples-drawer="open">
+             drawer="open">
 </cdx-summary>
 ```

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -173,7 +173,7 @@ ${this.overviewTable()}
 <h2>MIME Type and Status Code Distribution</h2>
 <p>
 The grid below shows HTTP status code groups of captures of various media types in this item/collection.
-The <code>Revisit</code> records do not represents an independent media type, instead, they reflect an unchanged state of representations of resources from some of their prior observations (i.e., the same content digest for the same URI).
+The <code>Revisit</code> records do not represent an independent media type, instead, they reflect an unchanged state of representations of resources from some of their prior observations (i.e., the same content digest for the same URI).
 The <code>TOTAL</code> column shows combined counts for each media type irrespective of their HTTP status code and the <code>TOTAL</code> row (displayed only if there are more than one media types listed) shows the combined counts of each HTTP status code group irrespective of their media types.
 </p>
 ${this.gridTable(this.data.mimestatus, 'MIME')}

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -287,6 +287,11 @@ ${this.sampleCapturesList()}
   }
   table {
     border-collapse: collapse;
+    display: block;
+    max-width: fit-content;
+    margin: 0 auto;
+    overflow-x: auto;
+    white-space: nowrap;
   }
   tr:nth-child(even), li:nth-child(even) {
     background-color: #eee;
@@ -336,6 +341,9 @@ ${this.sampleCapturesList()}
   }
   details.samples:not([open]) summary::after {
     content: attr(data-close);
+  }
+  .sample-thumbs {
+    text-align: center;
   }
   .thumb-container {
     width: 294px;

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -168,7 +168,7 @@ ${[...ridx].map(i => `
   <div class="thumb-container">
     <div class="thumb">
       <a href="${this.urim(s[i][0], s[i][1])}">${s[i][1]}</a>
-      <iframe src="${this.urim(s[i][0], s[i][1], 'if_')}" sandbox="allow-same-origin allow-scripts" scrolling="no" frameborder="0" onload="this.style.backgroundColor = 'white'"></iframe>
+      <iframe src="${this.urim(s[i][0], s[i][1], 'if_')}" sandbox="allow-same-origin allow-scripts" scrolling="no" frameborder="0" onload="this.style.backgroundColor='white'"></iframe>
     </div>
   </div>
 `).join('\n')}
@@ -268,7 +268,7 @@ ${this.sampleCapturesList()}
     padding: 5px;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   }
-  table { 
+  table {
     border-collapse: collapse;
   }
   tr:nth-child(even), li:nth-child(even) {

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -201,26 +201,26 @@ The <code>Total WARC Records Size</code> value is neither the combined size of t
 </p>
 ${this.overviewTable()}
 
-<h2>MIME Type and Status Code Distribution</h2>
+<h2>MIME Type and Status Code</h2>
 <p>
-The grid below shows HTTP status code groups of captures of various media types in this item/collection.
+The matrix below shows HTTP status code groups of captures of various media types in this item/collection.
 The <code>Revisit</code> records do not represent an independent media type, instead, they reflect an unchanged state of representations of resources from some of their prior observations (i.e., the same content digest for the same URI).
 The <code>TOTAL</code> column shows combined counts for each media type irrespective of their HTTP status code and the <code>TOTAL</code> row (displayed only if there are more than one media types listed) shows the combined counts of each HTTP status code group irrespective of their media types.
 </p>
 ${this.gridTable(this.data.mimestatus, 'MIME')}
 
-<h2>Path and Query Segments</h2>
+<h2>Path Segment and Query Parameter</h2>
 <p>
-The grid below shows the number of path segments and the number of query parameters of various URIs in this item/collection.
+The matrix below shows the number of path segments and the number of query parameters of various URIs in this item/collection.
 For example, the cell <code>P0</code> and <code>Q0</code> shows the number of captures of homepages of various hosts with zero path segments and zero query parameters.
 The URI <code>https://example.com/img/logo.png?width=300&height=100&screen=highres</code> has two path segments (i.e., <code>/img/logo.png</code>) and three query parameters (i.e., <code>width=300&height=100&screen=highres</code>), hence counted under the <code>P2</code> and <code>Q3</code> cell.
 The <code>TOTAL</code> column shows combined counts for URIs with a specific number of path segments irrespective of their number of query parameters and the <code>TOTAL</code> row (displayed only if there are URIs with a varying number of path segments) shows the combined counts for URIs with a specific number of query parameters irrespective of their number of path segments.
 </p>
 ${this.gridTable(this.data.pathquery, 'Path')}
 
-<h2>Year and Month Distribution</h2>
+<h2>Year and Month</h2>
 <p>
-The grid below shows the number of captures of this item/collection observed in different calendar years and months.
+The matrix below shows the number of captures of this item/collection observed in different calendar years and months.
 The <code>TOTAL</code> column shows combined counts for corresponding years and the <code>TOTAL</code> row (displayed only if the captures were observed across multiple calendar years) shows the combined number of captures observed in the corresponding calendar months irrespective of their years.
 </p>
 ${this.gridTable(this.data.yearmonth, 'Year', Object.keys(Object.values(this.data.yearmonth)[0]).sort(), this.toMonth)}

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -185,8 +185,8 @@ ${[...ridx].map(i => `
 
     container.innerHTML = `
 <p>
-The summary below is based on the <a href="${this.src}">Item/Collection Summary JSON</a> file.
-A more comprehensive <a href="${this.src.replace(/\.summary\.json$/, '.report.json.gz')}">Item/Collection Report</a> file is available for detailed analysis and research.
+The summary of the <i>${this.title}</i> ${this.type} below is based on the <a href="${this.src}">summary JSON file</a>.
+${this.report ? `A more comprehensive <a href="${this.report}">report JSON file</a> is available for detailed analysis and research.` : ''}
 </p>
 
 <p class="info">
@@ -194,16 +194,16 @@ Hover over on numeric cells to see the percentage value in the tooltip w.r.t. th
 Insignificant values might be reported as <code>0.00%</code>.
 </p>
 
-<h2>CDX Overview</h2>
+<h2>Overview</h2>
 <p>
-This overview is based on the sorted unique capture index (CDX) file of all the WARC files in the item/collection.
+This overview is based on the sorted unique capture index (CDX) file of all the WARC files in the ${this.type}.
 The <code>Total WARC Records Size</code> value is neither the combined size of the WARC files nor the sum of the sizes of the archived resources, instead, it is the sum of the sizes of the compressed WARC Response records (including their headers).
 </p>
 ${this.overviewTable()}
 
 <h2>MIME Type and Status Code</h2>
 <p>
-The matrix below shows HTTP status code groups of captures of various media types in this item/collection.
+The matrix below shows HTTP status code groups of captures of various media types in this ${this.type}.
 The <code>Revisit</code> records do not represent an independent media type, instead, they reflect an unchanged state of representations of resources from some of their prior observations (i.e., the same content digest for the same URI).
 The <code>TOTAL</code> column shows combined counts for each media type irrespective of their HTTP status code and the <code>TOTAL</code> row (displayed only if there are more than one media types listed) shows the combined counts of each HTTP status code group irrespective of their media types.
 </p>
@@ -211,7 +211,7 @@ ${this.gridTable(this.data.mimestatus, 'MIME')}
 
 <h2>Path Segment and Query Parameter</h2>
 <p>
-The matrix below shows the number of path segments and the number of query parameters of various URIs in this item/collection.
+The matrix below shows the number of path segments and the number of query parameters of various URIs in this ${this.type}.
 For example, the cell <code>P0</code> and <code>Q0</code> shows the number of captures of homepages of various hosts with zero path segments and zero query parameters.
 The URI <code>https://example.com/img/logo.png?width=300&height=100&screen=highres</code> has two path segments (i.e., <code>/img/logo.png</code>) and three query parameters (i.e., <code>width=300&height=100&screen=highres</code>), hence counted under the <code>P2</code> and <code>Q3</code> cell.
 The <code>TOTAL</code> column shows combined counts for URIs with a specific number of path segments irrespective of their number of query parameters and the <code>TOTAL</code> row (displayed only if there are URIs with a varying number of path segments) shows the combined counts for URIs with a specific number of query parameters irrespective of their number of path segments.
@@ -220,14 +220,14 @@ ${this.gridTable(this.data.pathquery, 'Path')}
 
 <h2>Year and Month</h2>
 <p>
-The matrix below shows the number of captures of this item/collection observed in different calendar years and months.
+The matrix below shows the number of captures of this ${this.type} observed in different calendar years and months.
 The <code>TOTAL</code> column shows combined counts for corresponding years and the <code>TOTAL</code> row (displayed only if the captures were observed across multiple calendar years) shows the combined number of captures observed in the corresponding calendar months irrespective of their years.
 </p>
 ${this.gridTable(this.data.yearmonth, 'Year', Object.keys(Object.values(this.data.yearmonth)[0]).sort(), this.toMonth)}
 
 <h2>Top <i>${this.toNum(Object.keys(this.data.tophosts).length)}</i> Out of <i>${this.toNum(this.data.hosts)}</i> Hosts</h2>
 <p>
-The table below shows the top hosts of this item/collection based on the number of captures of URIs from each host.
+The table below shows the top hosts of this ${this.type} based on the number of captures of URIs from each host.
 The <code>OTHERS</code> row, if present, is the sum of the longtail of hosts.
 </p>
 ${this.topHostsTable()}
@@ -235,7 +235,7 @@ ${this.topHostsTable()}
 <h2>Random HTML Capture Samples</h2>
 ${this.sampleThumbs()}
 <p>
-Below is a list of random sample of captured URIs linked to their corresponding Wayback Machine playback URIs from this item/collection.
+Below is a list of random sample of captured URIs linked to their corresponding Wayback Machine playback URIs from this ${this.type}.
 The sample is chosen only from captures that were observed with the <code>text/html</code> media type and <code>200 OK</code> HTTP status code.
 Any unexpected URIs listed below (e.g., with a <code>.png/.jpg/.pdf</code> file extension) are likely a result of the Soft-404 issue from the origin server.
 </p>
@@ -256,10 +256,19 @@ ${this.sampleCapturesList()}
     this.playback = (this.getAttribute('playback') || this.WAYBACK).replace(/\/+$/, '');
     this.thumbs = ((parseInt(this.getAttribute('thumbs'))+1) || 5)-1;
     this.drawer = this.getAttribute('samples-drawer') || '';
+    this.type = this.getAttribute('type') || 'CDX';
+    this.title = this.getAttribute('title') || '';
+    this.report = this.getAttribute('report') || '';
     this.src = this.getAttribute('src') || '';
     this.item = this.getAttribute('item') || '';
     if(this.item && !this.src) {
       this.src = `${this.PETABOX}${this.item}/${this.item}.summary.json`;
+    }
+    if(this.item && !this.report) {
+      this.report = `${this.PETABOX}${this.item}/${this.item}.report.json.gz`;
+    }
+    if(!this.title) {
+      this.title = this.src.split('/').pop().replace(/(.summary)?.json$/, '');
     }
     this.data['msg'] = this.src ? 'Loading summary...' : 'Either "src" or "item" attribute is required for the &lt;cdx-summary&gt; element!';
 

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -143,9 +143,12 @@ export class CDXSummary extends HTMLElement {
 
   sampleCapturesList() {
     return `
+<details class="samples">
+<summary data-open="Hide Sample URIs" data-close="Show ${this.data.samples.length} Random Sample URIs"></summary>
 <ul>
 ${this.data.samples.map(s => s.concat(s[1].replace(/^(https?:\/\/)?(www\.)?/i, ''))).sort((a, b) => a[2].length - b[2].length).map(s => `<li><a href="${this.WAYBACK}${s[0]}/${s[1]}">${s[2]}</a></li>`).join('\n')}
 </ul>
+</details>
 `;
   }
 
@@ -205,7 +208,7 @@ The <code>OTHERS</code> row, if present, is the sum of the longtail of hosts.
 </p>
 ${this.topHostsTable()}
 
-<h2><i>${this.data.samples.length}</i> Random Samples of <i>OK HTML</i> Captures</h2>
+<h2>Random HTML Capture Samples</h2>
 <p>
 Below is a list of random sample of captured URIs linked to their corresponding Wayback Machine playback URIs from this item/collection.
 The sample is chosen only from captures that were observed with the <code>text/html</code> media type and <code>200 OK</code> HTTP status code.
@@ -277,6 +280,18 @@ ${this.sampleCapturesList()}
   }
   .info::before {
     content: "🛈 ";
+  }
+  summary {
+    cursor: pointer;
+  }
+  details {
+    margin-bottom: 20px;
+  }
+  details.samples[open] summary::after {
+    content: attr(data-open);
+  }
+  details.samples:not([open]) summary::after {
+    content: attr(data-close);
   }
 </style>
 <div id="container">

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -156,7 +156,7 @@ ${this.data.samples.map(s => s.concat(s[1].replace(/^(https?:\/\/)?(www\.)?/i, '
 `;
   }
 
-  sampleCards() {
+  sampleThumbs() {
     let s = this.data.samples;
     const ridx = new Set();
     while (ridx.size < Math.min(this.thumbs, s.length)) {
@@ -233,7 +233,7 @@ The <code>OTHERS</code> row, if present, is the sum of the longtail of hosts.
 ${this.topHostsTable()}
 
 <h2>Random HTML Capture Samples</h2>
-${this.sampleCards()}
+${this.sampleThumbs()}
 <p>
 Below is a list of random sample of captured URIs linked to their corresponding Wayback Machine playback URIs from this item/collection.
 The sample is chosen only from captures that were observed with the <code>text/html</code> media type and <code>200 OK</code> HTTP status code.

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -185,7 +185,7 @@ ${[...ridx].map(i => `
 
     container.innerHTML = `
 <p>
-The summary of the <i>${this.title}</i> ${this.type} below is based on the <a href="${this.src}">summary JSON file</a>.
+The summary of the <i>${this.name}</i> ${this.type} below is based on the <a href="${this.src}">summary JSON file</a>.
 ${this.report ? `A more comprehensive <a href="${this.report}">report JSON file</a> is available for detailed analysis and research.` : ''}
 </p>
 
@@ -257,7 +257,7 @@ ${this.sampleCapturesList()}
     this.thumbs = ((parseInt(this.getAttribute('thumbs'))+1) || 5)-1;
     this.drawer = this.getAttribute('samples-drawer') || '';
     this.type = this.getAttribute('type') || 'CDX';
-    this.title = this.getAttribute('title') || '';
+    this.name = this.getAttribute('name') || '';
     this.report = this.getAttribute('report') || '';
     this.src = this.getAttribute('src') || '';
     this.item = this.getAttribute('item') || '';
@@ -267,8 +267,8 @@ ${this.sampleCapturesList()}
     if(this.item && !this.report) {
       this.report = `${this.PETABOX}${this.item}/${this.item}.report.json.gz`;
     }
-    if(!this.title) {
-      this.title = this.src.split('/').pop().replace(/(.summary)?.json$/, '');
+    if(!this.name) {
+      this.name = this.src.split('/').pop().replace(/(.summary)?.json$/, '');
     }
     this.data['msg'] = this.src ? 'Loading summary...' : 'Either "src" or "item" attribute is required for the &lt;cdx-summary&gt; element!';
 

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -168,7 +168,7 @@ ${[...ridx].map(i => `
   <div class="thumb-container">
     <div class="thumb">
       <a href="${this.urim(s[i][0], s[i][1])}">${s[i][1]}</a>
-      <iframe src="${this.urim(s[i][0], s[i][1], 'if_')}" scrolling="no" frameborder="0" onload="this.style.backgroundColor = 'white'"></iframe>
+      <iframe src="${this.urim(s[i][0], s[i][1], 'if_')}" sandbox="allow-same-origin allow-scripts" scrolling="no" frameborder="0" onload="this.style.backgroundColor = 'white'"></iframe>
     </div>
   </div>
 `).join('\n')}

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -18,6 +18,10 @@ export class CDXSummary extends HTMLElement {
     return `${dt.substring(0, 4)}-${dt.substring(4, 6)}-${dt.substring(6, 8)}`;
   }
 
+  toMonth(m) {
+    return (new Date(1970, m-1, 15)).toLocaleDateString('default', {month: 'short'});
+  }
+
   toNum(n) {
     return new Intl.NumberFormat().format(n);
   }
@@ -67,8 +71,8 @@ export class CDXSummary extends HTMLElement {
 `;
   }
 
-  gridTable(obj, group='', cols) {
-    if (!cols) {
+  gridTable(obj, group='', cols=[], format=c=>c) {
+    if (!cols.length) {
       cols = Object.keys(Object.values(obj)[0]);
     }
     const colSum = cols.reduce((a, k) => {a[k] = 0; return a}, {});
@@ -77,7 +81,7 @@ export class CDXSummary extends HTMLElement {
   <thead>
     <tr>
       <th scope="col">${group}</th>
-      ${cols.map(c => `<th scope="col">${c}</th>`).join('\n')}
+      ${cols.map(c => `<th scope="col">${format(c)}</th>`).join('\n')}
       <th scope="col">TOTAL</th>
     </tr>
   </thead>
@@ -191,7 +195,7 @@ ${this.gridTable(this.data.pathquery, 'Path')}
 The grid below shows the number of captures of this item/collection observed in different calendar years and months.
 The <code>TOTAL</code> column shows combined counts for corresponding years and the <code>TOTAL</code> row (displayed only if the captures were observed across multiple calendar years) shows the combined number of captures observed in the corresponding calendar months irrespective of their years.
 </p>
-${this.gridTable(this.data.yearmonth, 'Year', Object.keys(Object.values(this.data.yearmonth)[0]).sort())}
+${this.gridTable(this.data.yearmonth, 'Year', Object.keys(Object.values(this.data.yearmonth)[0]).sort(), this.toMonth)}
 
 <h2>Top <i>${this.toNum(Object.keys(this.data.tophosts).length)}</i> Out of <i>${this.toNum(this.data.hosts)}</i> Hosts</h2>
 <p>

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -156,6 +156,26 @@ ${this.data.samples.map(s => s.concat(s[1].replace(/^(https?:\/\/)?(www\.)?/i, '
 `;
   }
 
+  sampleCards() {
+    let s = this.data.samples;
+    const ridx = new Set();
+    while (ridx.size < Math.min(this.thumbs, s.length)) {
+      ridx.add(Math.floor(Math.random()*s.length));
+    }
+    return `
+<div class="sample-thumbs">
+${[...ridx].map(i => `
+  <div class="thumb-container">
+    <div class="thumb">
+      <a href="${this.urim(s[i][0], s[i][1])}">${s[i][1]}</a>
+      <iframe src="${this.urim(s[i][0], s[i][1], 'if_')}" scrolling="no" frameborder="0" onload="this.style.backgroundColor = 'white'"></iframe>
+    </div>
+  </div>
+`).join('\n')}
+</div>
+`;
+  }
+
   renderSummary() {
     const container = this.shadow.getElementById('container');
     if (this.data['msg']) {
@@ -213,6 +233,7 @@ The <code>OTHERS</code> row, if present, is the sum of the longtail of hosts.
 ${this.topHostsTable()}
 
 <h2>Random HTML Capture Samples</h2>
+${this.sampleCards()}
 <p>
 Below is a list of random sample of captured URIs linked to their corresponding Wayback Machine playback URIs from this item/collection.
 The sample is chosen only from captures that were observed with the <code>text/html</code> media type and <code>200 OK</code> HTTP status code.
@@ -233,6 +254,7 @@ ${this.sampleCapturesList()}
 
   async connectedCallback() {
     this.playback = (this.getAttribute('playback') || this.WAYBACK).replace(/\/+$/, '');
+    this.thumbs = ((parseInt(this.getAttribute('thumbs'))+1) || 5)-1;
     this.src = this.getAttribute('src') || '';
     this.item = this.getAttribute('item') || '';
     if(this.item && !this.src) {
@@ -297,6 +319,43 @@ ${this.sampleCapturesList()}
   }
   details.samples:not([open]) summary::after {
     content: attr(data-close);
+  }
+  .thumb-container {
+    width: 294px;
+    height: 186px;
+    display: inline-block;
+    overflow: hidden;
+    position: relative;
+  }
+  .thumb {
+    width: 288px;
+    height: 180px;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 2px;
+    background-color: #fff;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 58 58' style='enable-background:new 0 0 58 58' xml:space='preserve'%3E%3Cpath fill='lightgray' d='M31 56h24V32H31v24zm2-22h9v12.586l-4.293-4.293-1.414 1.414L43 50.414l6.707-6.707-1.414-1.414L44 46.586V34h9v20H33V34zM21.569 13.569C21.569 10.498 19.071 8 16 8s-5.569 2.498-5.569 5.569c0 3.07 2.498 5.568 5.569 5.568s5.569-2.497 5.569-5.568zm-9.138 0C12.431 11.602 14.032 10 16 10s3.569 1.602 3.569 3.569-1.601 3.569-3.569 3.569-3.569-1.601-3.569-3.569zM6.25 36.661a.997.997 0 0 0 1.41.09l16.313-14.362 7.319 7.318a.999.999 0 1 0 1.414-1.414l-1.825-1.824 9.181-10.054 11.261 10.323a1 1 0 0 0 1.351-1.475l-12-11a1.002 1.002 0 0 0-1.414.063l-9.794 10.727-4.743-4.743a1.003 1.003 0 0 0-1.368-.044L6.339 35.249a1 1 0 0 0-.089 1.412z'/%3E%3Cpath fill='lightgray' d='M57 2H1a1 1 0 0 0-1 1v44a1 1 0 0 0 1 1h24a1 1 0 1 0 0-2H2V4h54v25a1 1 0 1 0 2 0V3a1 1 0 0 0-1-1z'/%3E%3C/svg%3E");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 30%;
+  }
+  .thumb a {
+    display: block;
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    color: #fff;
+    background: #fff;
+    opacity: 0;
+  }
+  .thumb iframe {
+    overflow: hidden;
+    position: relative;
+    z-index: 1;
+    width: 960px;
+    height: 600px;
+    transform-origin: 0 0;
+    transform: scale(0.3, 0.3);
   }
 </style>
 <div id="container">

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -146,7 +146,7 @@ export class CDXSummary extends HTMLElement {
 <details class="samples">
 <summary data-open="Hide Sample URIs" data-close="Show ${this.data.samples.length} Random Sample URIs"></summary>
 <ul>
-${this.data.samples.map(s => s.concat(s[1].replace(/^(https?:\/\/)?(www\.)?/i, ''))).sort((a, b) => a[2].length - b[2].length).map(s => `<li><a href="${this.WAYBACK}${s[0]}/${s[1]}">${s[2]}</a></li>`).join('\n')}
+${this.data.samples.map(s => s.concat(s[1].replace(/^(https?:\/\/)?(www\.)?/i, ''))).sort((a, b) => a[2].length - b[2].length).map(s => `<li><a href="${this.playback.replace(/\/+$/, '')}/${s[0]}/${s[1]}">${s[2]}</a></li>`).join('\n')}
 </ul>
 </details>
 `;
@@ -228,6 +228,7 @@ ${this.sampleCapturesList()}
   }
 
   async connectedCallback() {
+    this.playback = this.getAttribute('playback') || this.WAYBACK;
     this.src = this.getAttribute('src') || '';
     this.item = this.getAttribute('item') || '';
     if(this.item && !this.src) {

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -186,6 +186,7 @@ ${this.gridTable(this.data.mimestatus, 'MIME')}
 <p>
 The grid below shows the number of path segments and the number of query parameters of various URIs in this item/collection.
 For example, the cell <code>P0</code> and <code>Q0</code> shows the number of captures of homepages of various hosts with zero path segments and zero query parameters.
+The URI <code>https://example.com/img/logo.png?width=300&height=100&screen=highres</code> has two path segments (i.e., <code>/img/logo.png</code>) and three query parameters (i.e., <code>width=300&height=100&screen=highres</code>), hence counted under the <code>P2</code> and <code>Q3</code> cell.
 The <code>TOTAL</code> column shows combined counts for URIs with a specific number of path segments irrespective of their number of query parameters and the <code>TOTAL</code> row (displayed only if there are URIs with a varying number of path segments) shows the combined counts for URIs with a specific number of query parameters irrespective of their number of path segments.
 </p>
 ${this.gridTable(this.data.pathquery, 'Path')}

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -10,8 +10,13 @@ export class CDXSummary extends HTMLElement {
   }
 
   toFs(s) {
-    let i = Math.floor(Math.log(s)/Math.log(1024));
-    return `${Number((s/Math.pow(1024, i)).toFixed(2))} ${['B', 'kB', 'MB', 'GB', 'TB'][i]}`;
+    let i = Math.log(s)/Math.log(1024) | 0;
+    return `${Number((s/Math.pow(1024, i)).toFixed(2))} ${['B', 'KB', 'MB', 'GB', 'TB'][i]}`;
+  }
+
+  toSn(n) {
+    let i = Math.log10(n)/3 | 0;
+    return `${Number((n/Math.pow(1000, i)).toFixed(1))}${['', 'K', 'M', 'B', 'T'][i]}`;
   }
 
   toDate(dt) {
@@ -31,7 +36,7 @@ export class CDXSummary extends HTMLElement {
   }
 
   numCell(n) {
-    return `<td title="${this.toPerc(n)}">${this.toNum(n)}</td>`;
+    return `<td title="${this.toSn(n)}\n${this.toPerc(n)}">${this.toNum(n)}</td>`;
   }
 
   numSum(nums) {

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -147,7 +147,7 @@ export class CDXSummary extends HTMLElement {
 
   sampleCapturesList() {
     return `
-<details class="samples">
+<details ${this.drawer} class="samples">
 <summary data-open="Hide Sample URIs" data-close="Show ${this.data.samples.length} Random Sample URIs"></summary>
 <ul>
 ${this.data.samples.map(s => s.concat(s[1].replace(/^(https?:\/\/)?(www\.)?/i, ''))).sort((a, b) => a[2].length - b[2].length).map(s => `<li><a href="${this.urim(s[0], s[1])}">${s[2]}</a></li>`).join('\n')}
@@ -255,6 +255,7 @@ ${this.sampleCapturesList()}
   async connectedCallback() {
     this.playback = (this.getAttribute('playback') || this.WAYBACK).replace(/\/+$/, '');
     this.thumbs = ((parseInt(this.getAttribute('thumbs'))+1) || 5)-1;
+    this.drawer = this.getAttribute('samples-drawer') || '';
     this.src = this.getAttribute('src') || '';
     this.item = this.getAttribute('item') || '';
     if(this.item && !this.src) {

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -38,6 +38,10 @@ export class CDXSummary extends HTMLElement {
     return nums.reduce((s, v) => s + v, 0);
   }
 
+  urim(dt, urir, mod='') {
+    return `${this.playback}/${dt}${mod}/${urir}`;
+  }
+
   overviewTable() {
     return `
 <table>
@@ -146,7 +150,7 @@ export class CDXSummary extends HTMLElement {
 <details class="samples">
 <summary data-open="Hide Sample URIs" data-close="Show ${this.data.samples.length} Random Sample URIs"></summary>
 <ul>
-${this.data.samples.map(s => s.concat(s[1].replace(/^(https?:\/\/)?(www\.)?/i, ''))).sort((a, b) => a[2].length - b[2].length).map(s => `<li><a href="${this.playback.replace(/\/+$/, '')}/${s[0]}/${s[1]}">${s[2]}</a></li>`).join('\n')}
+${this.data.samples.map(s => s.concat(s[1].replace(/^(https?:\/\/)?(www\.)?/i, ''))).sort((a, b) => a[2].length - b[2].length).map(s => `<li><a href="${this.urim(s[0], s[1])}">${s[2]}</a></li>`).join('\n')}
 </ul>
 </details>
 `;
@@ -228,7 +232,7 @@ ${this.sampleCapturesList()}
   }
 
   async connectedCallback() {
-    this.playback = this.getAttribute('playback') || this.WAYBACK;
+    this.playback = (this.getAttribute('playback') || this.WAYBACK).replace(/\/+$/, '');
     this.src = this.getAttribute('src') || '';
     this.item = this.getAttribute('item') || '';
     if(this.item && !this.src) {

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -195,7 +195,7 @@ ${this.report ? `A more comprehensive <a href="${this.report}">report JSON file<
 </p>
 
 <p class="info">
-Hover over on numeric cells to see the percentage value in the tooltip w.r.t. the total number of captures.
+Hover over on numeric cells to see the values in various formats in the tooltip (percentage values are w.r.t. the total number of captures).
 Insignificant values might be reported as <code>0.00%</code>.
 </p>
 

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -262,7 +262,7 @@ ${this.sampleCapturesList()}
     this.thumbs = ((parseInt(this.getAttribute('thumbs'))+1) || 5)-1;
     this.format = this.getAttribute('format') || 'local';
     this.formatter = (this.format == 'short') ? this.toSn : (this.format == 'percent') ? this.toPerc : this.toNum
-    this.drawer = this.getAttribute('samples-drawer') || '';
+    this.drawer = this.getAttribute('drawer') || '';
     this.type = this.getAttribute('type') || 'CDX';
     this.name = this.getAttribute('name') || '';
     this.report = this.getAttribute('report') || '';

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -35,8 +35,8 @@ export class CDXSummary extends HTMLElement {
     return `${(n*100/this.data.captures).toFixed(2)}%`;
   }
 
-  numCell(n) {
-    return `<td title="${this.toSn(n)}\n${this.toPerc(n)}">${this.toNum(n)}</td>`;
+  numCell(n, h='') {
+    return `<td title="${[h, this.toPerc(n), this.toSn(n), this.toNum(n)].filter(i => i).join('\n')}">${this.formatter(n)}</td>`;
   }
 
   numSum(nums) {
@@ -101,9 +101,9 @@ export class CDXSummary extends HTMLElement {
       <th scope="row">${o[0]}</th>
       ${cols.map(c => {
         colSum[c] += o[1][c];
-        return this.numCell(o[1][c]);
+        return this.numCell(o[1][c], `${o[0]} - ${format(c)}`);
       }).join('\n')}
-      ${this.numCell(this.numSum(Object.values(o[1])))}
+      ${this.numCell(this.numSum(Object.values(o[1])), o[0])}
     </tr>`
   }).join('\n')}
   </tbody>
@@ -111,8 +111,8 @@ export class CDXSummary extends HTMLElement {
   <tfoot>
     <tr>
       <th scope="col">TOTAL</th>
-      ${cols.map(c => this.numCell(colSum[c])).join('\n')}
-      ${this.numCell(this.data.captures)}
+      ${cols.map(c => this.numCell(colSum[c], format(c))).join('\n')}
+      ${this.numCell(this.data.captures, 'ALL')}
     </tr>
   </tfoot>`}
 </table>
@@ -135,7 +135,7 @@ export class CDXSummary extends HTMLElement {
     return `
     <tr>
       <th scope="row">${h[0]}</th>
-      ${this.numCell(h[1])}
+      ${this.numCell(h[1], h[0])}
     </tr>`
   }).join('\n')}
   </tbody>
@@ -143,7 +143,7 @@ export class CDXSummary extends HTMLElement {
   <tfoot>
     <tr>
       <th scope="row">OTHERS (${this.toNum(otherHostsCount)} Hosts)</th>
-      ${this.numCell(otherHostsTotal)}
+      ${this.numCell(otherHostsTotal, 'OTHERS')}
     </tr>
   </tfoot>`}
 </table>
@@ -260,6 +260,8 @@ ${this.sampleCapturesList()}
   async connectedCallback() {
     this.playback = (this.getAttribute('playback') || this.WAYBACK).replace(/\/+$/, '');
     this.thumbs = ((parseInt(this.getAttribute('thumbs'))+1) || 5)-1;
+    this.format = this.getAttribute('format') || 'local';
+    this.formatter = (this.format == 'short') ? this.toSn : (this.format == 'percent') ? this.toPerc : this.toNum
     this.drawer = this.getAttribute('samples-drawer') || '';
     this.type = this.getAttribute('type') || 'CDX';
     this.name = this.getAttribute('name') || '';

--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -11,7 +11,7 @@ export class CDXSummary extends HTMLElement {
 
   toFs(s) {
     let i = Math.floor(Math.log(s)/Math.log(1024));
-    return (s/Math.pow(1024, i)).toFixed(2) * 1 + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
+    return `${Number((s/Math.pow(1024, i)).toFixed(2))} ${['B', 'kB', 'MB', 'GB', 'TB'][i]}`;
   }
 
   toDate(dt) {

--- a/webcomponent/index.html
+++ b/webcomponent/index.html
@@ -47,6 +47,7 @@
   <script>
     const lists = {
       "attr": ["src", "item", "name", "report", "playback", "type", "format", "thumbs", "drawer"],
+      "src": ["samples/MC.summary.json", "samples/EoT20.summary.json"],
       "item": ["mediacloud", "EndOfTerm2020WebCrawls", "epa-via-sitemap"],
       "type": ["CDX", "collection", "item"],
       "format": ["short", "percent", "local"]
@@ -60,7 +61,8 @@
     const visf = `
     <form id="cdxsummary">
       &lt;cdx-summary
-      ${f('src')}<input name="src" value="${g('src')}" placeholder="Summary file URL (Optional if item is provided)" class="wide-input">&quot;
+      ${f('src')}<input name="src" value="${g('src')}" placeholder="Summary file URL (Optional if item is provided)" list="src-list" class="wide-input">&quot;
+      ${d('src')}
       ${f('item')}<input name="item" value="${g('item')}" placeholder="Collection/Item ID (Optional if src is provided)" list="item-list" class="wide-input">&quot;
       ${d('item')}
       ${f('name')}<input name="name" value="${g('name')}" placeholder="Default: Derived from filename" class="wide-input">&quot;

--- a/webcomponent/index.html
+++ b/webcomponent/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CDX Summary Tester</title>
+  <style>
+    body {
+      margin: 0;
+    }
+    h1 {
+      background: #111;
+      color: #eee;
+      padding: 10px;
+      margin: 0 auto;
+      text-align: center;
+      font-family: sans-serif;
+    }
+    form {
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    #form-container {
+      background: #ccc;
+      padding: 5px;
+      font-family: mono;
+    }
+    #code-container {
+      background: #111;
+      color: #eee;
+      margin: 0;
+      padding: 5px 10px;
+      text-align: center;
+      overflow: auto;
+    }
+    .wide-input {
+      width: 300px;
+    }
+    .narrow-input {
+      width: 150px;
+    }
+    .submit {
+      float: right;
+      margin-top: -5px;
+    }
+  </style>
+  <script type="module" src="cdxsummary.js"></script>
+  <script>
+    const lists = {
+      "attr": ["src", "item", "name", "report", "playback", "type", "format", "thumbs", "drawer"],
+      "item": ["mediacloud", "EndOfTerm2020WebCrawls", "epa-via-sitemap"],
+      "type": ["CDX", "collection", "item"],
+      "format": ["short", "percent", "local"]
+    };
+    const l = Math.max(...(lists["attr"].map(el => el.length)));
+    const q = new URLSearchParams(location.search);
+    const g = a => q.get(a) || '';
+    const f = a => `<br>&nbsp;&nbsp;&nbsp;&nbsp;${a}${'&nbsp;'.repeat(l+1-a.length)}=&nbsp;&quot;`;
+    const d = a => `<datalist id="${a}-list">${lists[a].map(i => `<option value="${i}">`).join('')}</datalist>`;
+    const elm = `<cdx-summary ${lists["attr"].filter(a => q.has(a)).map(i => `${i}="${g(i)}"`).join(' ')}></cdx-summary>`;
+    const visf = `
+    <form id="cdxsummary">
+      &lt;cdx-summary
+      ${f('src')}<input name="src" value="${g('src')}" placeholder="Summary file URL (Optional if item is provided)" class="wide-input">&quot;
+      ${f('item')}<input name="item" value="${g('item')}" placeholder="Collection/Item ID (Optional if src is provided)" list="item-list" class="wide-input">&quot;
+      ${d('item')}
+      ${f('name')}<input name="name" value="${g('name')}" placeholder="Default: Derived from filename" class="wide-input">&quot;
+      ${f('report')}<input name="report" value="${g('report')}" placeholder="Default: Derived from item" class="wide-input">&quot;
+      ${f('playback')}<input name="playback" value="${g('playback')}" placeholder="Default: https://web.archive.org/web/" class="wide-input">&quot;
+      ${f('type')}<input name="type" value="${g('type')}" placeholder="Default: CDX" list="type-list" class="narrow-input">&quot;
+      ${d('type')}
+      ${f('format')}<input name="format" value="${g('format')}" placeholder="Default: local" list="format-list" class="narrow-input">&quot;
+      ${d('format')}
+      ${f('thumbs')}<input name="thumbs" value="${g('thumbs')}" type="number" min="0" placeholder="Thumbnail count" class="narrow-input">&quot;
+      ${f('drawer')}<input name="drawer" value="open" type="checkbox" id="drawer"${g('drawer')=='open' ? ' checked' : ''}>
+      <label for="drawer">open</label>&quot;
+      <br>
+      &gt;&lt;/cdx-summary&gt;
+      <input type="submit" value="Render" class="submit">
+    </form>`;
+
+    document.addEventListener('formdata', e => Array.from(e.formData).filter(([k, v]) => v == '').map(([k, v]) => e.formData.delete(k)));
+    window.onload = () => {
+      document.getElementById('form-container').innerHTML = visf;
+      document.getElementById('code-out').innerText = elm;
+      document.getElementById('summary-container').innerHTML = elm;
+    };
+  </script>
+</head>
+<body>
+  <h1>CDX Summary Tester</h1>
+  <div id="form-container"></div>
+  <pre id="code-container"><code id="code-out"></code></pre>
+  <div id="summary-container"></div>
+</body>
+</html>

--- a/webcomponent/package.json
+++ b/webcomponent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/cdxsummary",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A Web Component to render CDX Summary JSON files",
   "main": "cdxsummary.js",
   "module": "cdxsummary.js",

--- a/webcomponent/samples/EoT20.summary.json
+++ b/webcomponent/samples/EoT20.summary.json
@@ -1,0 +1,605 @@
+{
+  "captures": 1599713767,
+  "urls": 906796744,
+  "hosts": 1396372,
+  "bytes": 289158184502345,
+  "first": "20201009165718",
+  "last": "20210531214138",
+  "tophosts": {
+    "godirect.gov": 27970110,
+    "zoneplate.lbl.gov": 24672475,
+    "gateway.womenshealth.gov": 18634496,
+    "riversideca.gov": 16997632,
+    "yanktongirlssoftball.com": 15788728,
+    "docarc.cstx.gov": 14982627,
+    "cliftonlivestock.com": 14756688,
+    "smgov.net": 14516744,
+    "domrep.org": 13793694,
+    "disc-beta.gsfc.nasa.gov": 13293849,
+    "transparency.treasury.gov": 12501553,
+    "twitter.com": 12184155,
+    "stjosephcountyindiana.com": 11821004,
+    "amnh.org": 11102585,
+    "eric.ed.gov": 11072824,
+    "lakeelmo.org": 10523319,
+    "shop.nga.gov": 10255124,
+    "fldep.dep.state.fl.us": 9989408,
+    "cityofnorthlasvegas.com": 9897695,
+    "docushare.xerox.com": 9811692
+  },
+  "mimestatus": {
+    "HTML": {
+      "2XX": 851177652,
+      "3XX": 494578100,
+      "4XX": 41454034,
+      "5XX": 4554043,
+      "Other": 1386
+    },
+    "Image": {
+      "2XX": 44300431,
+      "3XX": 36335,
+      "4XX": 21060,
+      "5XX": 734,
+      "Other": 0
+    },
+    "CSS": {
+      "2XX": 4439006,
+      "3XX": 576,
+      "4XX": 716,
+      "5XX": 38,
+      "Other": 0
+    },
+    "JavaScript": {
+      "2XX": 4400795,
+      "3XX": 810,
+      "4XX": 2158,
+      "5XX": 53,
+      "Other": 0
+    },
+    "JSON": {
+      "2XX": 3691208,
+      "3XX": 189886,
+      "4XX": 158445,
+      "5XX": 3361,
+      "Other": 14
+    },
+    "XML": {
+      "2XX": 7148560,
+      "3XX": 873499,
+      "4XX": 299052,
+      "5XX": 13540,
+      "Other": 0
+    },
+    "Text": {
+      "2XX": 17998669,
+      "3XX": 4870810,
+      "4XX": 6160565,
+      "5XX": 50424,
+      "Other": 0
+    },
+    "PDF": {
+      "2XX": 19041608,
+      "3XX": 331067,
+      "4XX": 5207,
+      "5XX": 36,
+      "Other": 0
+    },
+    "Font": {
+      "2XX": 365010,
+      "3XX": 20,
+      "4XX": 202,
+      "5XX": 7,
+      "Other": 0
+    },
+    "Audio": {
+      "2XX": 202037,
+      "3XX": 396,
+      "4XX": 1,
+      "5XX": 0,
+      "Other": 0
+    },
+    "Video": {
+      "2XX": 405765,
+      "3XX": 5815,
+      "4XX": 297,
+      "5XX": 2,
+      "Other": 0
+    },
+    "Revisit": {
+      "2XX": 0,
+      "3XX": 0,
+      "4XX": 0,
+      "5XX": 0,
+      "Other": 297036
+    },
+    "Other": {
+      "2XX": 20020764,
+      "3XX": 69817051,
+      "4XX": 2729356,
+      "5XX": 66130,
+      "Other": 0
+    }
+  },
+  "pathquery": {
+    "P0": {
+      "Q0": 106084299,
+      "Q1": 8226912,
+      "Q2": 2925331,
+      "Q3": 10487624,
+      "Q4": 5409111,
+      "Other": 7453637
+    },
+    "P1": {
+      "Q0": 278751033,
+      "Q1": 26563787,
+      "Q2": 17731586,
+      "Q3": 25687237,
+      "Q4": 42115265,
+      "Other": 49740721
+    },
+    "P2": {
+      "Q0": 164212602,
+      "Q1": 21325779,
+      "Q2": 23599613,
+      "Q3": 26504333,
+      "Q4": 21686779,
+      "Other": 38410315
+    },
+    "P3": {
+      "Q0": 53975457,
+      "Q1": 21301175,
+      "Q2": 7615021,
+      "Q3": 8768914,
+      "Q4": 11590397,
+      "Other": 26142236
+    },
+    "P4": {
+      "Q0": 65894706,
+      "Q1": 13717459,
+      "Q2": 3148806,
+      "Q3": 4278359,
+      "Q4": 6960742,
+      "Other": 8485917
+    },
+    "Other": {
+      "Q0": 432814746,
+      "Q1": 39842742,
+      "Q2": 7572526,
+      "Q3": 3604897,
+      "Q4": 937408,
+      "Other": 6146295
+    }
+  },
+  "yearmonth": {
+    "2020": {
+      "01": 0,
+      "02": 0,
+      "03": 0,
+      "04": 0,
+      "05": 0,
+      "06": 0,
+      "07": 0,
+      "08": 0,
+      "09": 0,
+      "10": 257769014,
+      "11": 335251668,
+      "12": 384880918
+    },
+    "2021": {
+      "01": 236592096,
+      "02": 2236,
+      "03": 72405443,
+      "04": 138068337,
+      "05": 174744055,
+      "06": 0,
+      "07": 0,
+      "08": 0,
+      "09": 0,
+      "10": 0,
+      "11": 0,
+      "12": 0
+    }
+  },
+  "samples": [
+    [
+      "20201114222149",
+      "https://www.algomacity.org/cityofalgoma/government/government/committees_agendas___minutes/departments/public_works_department/departments/finance/departments/_assets_/css/_assets_/plugins/modernizr/modernizr.custom.js"
+    ],
+    [
+      "20201009233029",
+      "https://rsicc.ornl.gov/javascript/App_Themes/Skin4/menumachine/javascript/menumachine/home/javascript/menumachine/javascript/menumachine/menumachine/home/javascript/javascript/menumachine/menumachine/home/menuspecs.js"
+    ],
+    [
+      "20201010233128",
+      "https://2014-2017.commerce.gov/sites/all/themes/doc/doc_theme/scripts/modules/system/misc/modules/user/sites/all/modules/contrib/views_tree/css/modules/search/searchd41d.css"
+    ],
+    [
+      "20201010150539",
+      "https://gateway.womenshealth.gov/bower_components/file-saver/bower_components/nvd3/build/vendor/leaflet-image/bower_components/dom-to-image/dist/bower_components/angular-translate-loader-static-files/bower_components/d3/bower_components/jstree/dist/jstree.js"
+    ],
+    [
+      "20210113035031",
+      "https://cdnp.flypgs.com/"
+    ],
+    [
+      "20210505182158",
+      "https://catalog.usmint.gov/coins/coin-programs/america-the-beautiful-quarters-program/tallgrass-prairie-national-preserve-kansas/?prefn1=coinFinish&prefv1=circulated&prefn2=enrollmentIsAvailable&prefv2=AT&pmin=25.00&pmax=50.00"
+    ],
+    [
+      "20201014164527",
+      "https://gateway.womenshealth.gov/bower_components/file-saver/bower_components/plotly.js/dist/app/components/owh-menu/bower_components/angular-ui-router/release/bower_components/jquery/dist/bower_components/d3/bower_components/angular-loader/app/app.resource.js"
+    ],
+    [
+      "20210326232402",
+      "https://upwell.pfeg.noaa.gov/erddap/info/noaa_esrl_e6c2_428b_cdd1/index.html"
+    ],
+    [
+      "20210426200303",
+      "http://www.usarmyjrotc.com/news/20/08/css2/scripts/lightbox2-master/dist/js/events/jlab.php"
+    ],
+    [
+      "20201019223754",
+      "https://www.tennille-ga.gov/officials/departments/public_works/departments/tennille_city_hall/living_and_visiting/where_to_shop.php"
+    ],
+    [
+      "20201219153747",
+      "https://www.westhaverstraw.org/government/departments/Documents%20Center/Resources/Forms/community/government/departments/_assets_/fonts/font-awesome/css/government/departments/building_department.php"
+    ],
+    [
+      "20201117181402",
+      "https://thegateway.org/Online/error.asp"
+    ],
+    [
+      "20201224103505",
+      "http://townofcopake.org/calendar/action~oneday/exact_date~1635739200/cat_ids~23,25,22,32,16/request_format~html/"
+    ],
+    [
+      "20201211091720",
+      "http://www.cityofnorthlasvegas.com/_assets_/fonts/departments/city_clerk/access_city_agendas_and_minutes/residents/departments/city_manager/residents/community_links/residents/residents_s_-_u/residents/community_links/post_offices.php"
+    ],
+    [
+      "20201111140835",
+      "https://www.transparency.treasury.gov/article/assets/reports/fir-mts/dataset/assets/reports/fir-rcm/lib/babel-polyfill/assets/reports/fir-dms/dataset/assets/reports/fir-rcm/rcm.min.js?v=131"
+    ],
+    [
+      "20210501144613",
+      "https://collections.nlm.nih.gov/?f%5Bdrep2.format%5D%5B%5D=Moving+image&f%5Bdrep2.subjectAggregate%5D%5B%5D=Dissection&f%5Bdrep2.subjectAggregate%5D%5B%5D=Mouth+Floor+--+anatomy+%26+histology&per_page=10"
+    ],
+    [
+      "20201020223449",
+      "https://www.townofwarren-ri.gov/town_government/departments/public_works/_assets_/fonts/font-awesome/css/i_want_to/_assets_/plugins/modernizr/modernizr.custom.js"
+    ],
+    [
+      "20201219001002",
+      "https://www.norwaymi.gov/departments/city_assessor/departments/city_manager/departments/city_code_enforcement_officer/_assets_/plugins/bootstrap/js/departments/fire_department/index.php"
+    ],
+    [
+      "20201024234714",
+      "https://heinonline.org/HOL/Index?index=statdocs&collection=statute"
+    ],
+    [
+      "20210119004111",
+      "https://eric.ed.gov/?q=%22%22&ff1=subHyperactivity&ff2=pubDissertations%2fTheses+-+Doctoral+Dissertations&ff3=subAdolescents&ff4=souProQuest+LLC"
+    ],
+    [
+      "20210522025339",
+      "https://toolkit.climate.gov/reports?f%5B0%5D=field_parent_topic%3A665&f%5B1%5D=field_state%3AMississippi&f%5B2%5D=field_state%3ANorth%20Dakota&f%5B3%5D=field_state%3AColorado"
+    ],
+    [
+      "20210408041529",
+      "https://www.invasivespeciesinfo.gov/resources-indexed?f%5B0%5D=field_location%3A84&f%5B1%5D=field_location%3A136&f%5B2%5D=field_location%3A145&f%5B3%5D=field_location%3A134&f%5B4%5D=field_location%3A158"
+    ],
+    [
+      "20210107235925",
+      "http://applibrary.orangecountync.gov/iii/calendar/list/C&M=7-2019/F;jsessionid=4758441ECBDE2A838D1D5B74B116DF36?lang=eng&suite=def"
+    ],
+    [
+      "20201016160631",
+      "https://www.americusga.gov/city-government"
+    ],
+    [
+      "20201221111225",
+      "http://domrep.org/"
+    ],
+    [
+      "20210408211329",
+      "https://e-learning.commerce.gov/ssLINK/NewsRoom/DeputySecretarySpeeches/s/websites/DOC/CommerceDeputySecretary/index.format_for_print-true.html"
+    ],
+    [
+      "20210103032220",
+      "https://www.transparency.treasury.gov/article/assets/reports/fir-open-data/assets/reports/fir-top/lib/marked/assets/reports/fir-top/assets/reports/fir-mts/lib/assets/reports/fir-top/lib/marked/lib/babel-polyfill/polyfill.min.js"
+    ],
+    [
+      "20201012031750",
+      "http://zoneplate.lbl.gov/img/css/lib/bootstrap/js/assets/lib/bootstrap/js/lib/bootstrap/css/css/lib/rhmiyakawa/lib/angular-1.2-2.16/angular-cookies.min.js"
+    ],
+    [
+      "20201024213533",
+      "http://www.legislature.maine.gov/statutes/24/title24sec957.html"
+    ],
+    [
+      "20201104132812",
+      "https://newspapers.library.in.gov/?a=a&command=ShowAuthenticateUserPage&opa=a%3dcl%26cl%3dCL2.1867.11%26e%3d20-02-1914-21-02-1914--en-20--1--txt-txIN-chirka------&e=20-02-1914-21-02-1914--en-20--1--txt-txIN-chirka------"
+    ],
+    [
+      "20201229123931",
+      "https://dotcms.fra.dot.gov/elibrary-search?f%5B0%5D=document_series%3A14741&f%5B1%5D=document_series%3A14776&f%5B2%5D=subject%3A14286&f%5B3%5D=subject%3A14301&f%5B4%5D=subject%3A14381&f%5B5%5D=subject%3A14436&f%5B6%5D=subject%3A14441&f%5B7%5D=subject%3A14541"
+    ],
+    [
+      "20201203114742",
+      "https://www.hilliardcorp.com/404.php"
+    ],
+    [
+      "20210325014038",
+      "https://edx.netl.doe.gov/dataset/?_tags_limit=0&tags=water&res_format=JPG"
+    ],
+    [
+      "20201130195057",
+      "https://www.nwk.usace.army.mil/Locations/District-Lakes/Smithville-Lake/igphoto/2000722451/igphoto/2000722939/igphoto/2000722840/igphoto/2000722916/igphoto/2000723064/igphoto/2000722530/igphoto/2000723067/"
+    ],
+    [
+      "20210326135026",
+      "https://www.psl.noaa.gov/thredds/catalog/Datasets/20thC_ReanV2c/pressure/catalog.html?dataset=Datasets/20thC_ReanV2c/pressure/shum.1958.nc"
+    ],
+    [
+      "20201122125250",
+      "https://www.drought.gov/drought/search/event?f%5B0%5D=field_states%3A129&f%5B1%5D=field_states%3A117&f%5B2%5D=field_states%3A93&f%5B3%5D=field_dews_regions%3A146&f%5B4%5D=field_states%3A90"
+    ],
+    [
+      "20201205053530",
+      "https://www.ogdenny.com/town_departments/assessors_office/_assets_/fonts/font-awesome/css/_assets_/js/town_departments/town_clerk/town_departments/building/planning_board.php"
+    ],
+    [
+      "20201104090615",
+      "http://www.cityofnorthlasvegas.com/_assets_/fonts/departments/city_manager/departments/community_development_and_compliance/docs/NLS/departments/city_manager/online_services/departments/mayor_and_council/departments/utilities/index.php"
+    ],
+    [
+      "20201009213630",
+      "https://disc-beta.gsfc.nasa.gov/fonts/bootstrap/lib/angular-toastr/dist/modules/commons/directives/spinner/modules/commons/directives/backToTop.js"
+    ],
+    [
+      "20201111145810",
+      "https://www.gatlinburgtn.gov/departments/planning/codes_and_permits/_assets_/plugins/modernizr/departments/sanitation/residents/information/_assets_/images/inner-logo.png"
+    ],
+    [
+      "20201218053018",
+      "https://www.azdhs.gov/preparedness/epidemiology-disease-control/infectious-disease-epidemiology/assets/plugins/html_markdown/bootstrap-markdown.min.js"
+    ],
+    [
+      "20201011101424",
+      "https://jsrunvisualizer.olcf.ornl.gov/resources/fonts/resources/bootstrap/resources/jquery/resources/fabric/resources/fabric/resources/bootstrap/resources/jquery/resources/fabric/resources/jquery/resources/example1.png"
+    ],
+    [
+      "20201020034602",
+      "https://www.ornl.gov/staff-profile/debanjana-nayak"
+    ],
+    [
+      "20201028103218",
+      "https://www.oxnard.org/event/tuesday-crafternoons-at-south-oxnard-2/?instance_id=9292274"
+    ],
+    [
+      "20210416045541",
+      "https://origin-www.acquisition.gov/search/advanced/%2A?f%5B0%5D=sm_field_part_number%3A2904&f%5B1%5D=bundle%3Adolar"
+    ],
+    [
+      "20201016180727",
+      "http://seattle.legistar.com/LegislationDetail.aspx?ID=3151928&GUID=EEFF882C-B64C-49DC-823A-67676A832B9C&Options=&Search="
+    ],
+    [
+      "20201109103816",
+      "https://www.twc.texas.gov/jobseekers"
+    ],
+    [
+      "20201016165054",
+      "https://teens.drugabuse.gov/national-drug-alcohol-facts-week/tweet-beyond-belief"
+    ],
+    [
+      "20210324215935",
+      "https://rmp.nlm.nih.gov/spotlight/ql/catalog?f%5Bexhibit_tags%5D%5B%5D=biographical&f%5Breadonly_genre_ssim%5D%5B%5D=Letters+%28correspondence%29"
+    ],
+    [
+      "20201029144039",
+      "https://blog.epa.gov/"
+    ],
+    [
+      "20201121082208",
+      "http://www.cityofnorthlasvegas.com/_assets_/css/residents/community_links/departments/human_resources/_assets_/img/departments/city_clerk/departments/city_clerk/access_city_agendas_and_minutes/docs/NLS/Park%20Trail%20Guide.pdf"
+    ],
+    [
+      "20201214031020",
+      "https://eric.ed.gov/?q=source%3a%22Literacy+Research+and+Instruction&ff1=souJournal+of+Educational+Computing+Research&ff2=dtySince_2016"
+    ],
+    [
+      "20201207170446",
+      "https://data.baltimorecity.gov/browse?Publishing-Entity_Department=Aging+and+Retirement+Education&category=City+Services&provenance=community&sortBy=relevance&tags=recreation"
+    ],
+    [
+      "20210331015743",
+      "https://www.justice.gov/crt/civil-rights-division-press-releases-speeches?f%5B0%5D=field_pr_component%3A436&f%5B1%5D=field_pr_date%3A2016&f%5B2%5D=field_pr_component%3A7751"
+    ],
+    [
+      "20201012065056",
+      "https://gateway.womenshealth.gov/bower_components/file-saver/app/css/bower_components/angular-awesome-slider/dist/css/bower_components/angular-route/app/components/owh-table/bower_components/angular-translate/app/services/map.service.js"
+    ],
+    [
+      "20201031231002",
+      "https://secure.tsp.gov/tsp/login.html"
+    ],
+    [
+      "20210512050534",
+      "https://snaped.fns.usda.gov/library/materials?lib%5B0%5D=format%3A8&lib%5B1%5D=format%3A31&lib%5B2%5D=setting%3A33&lib%5B3%5D=state%3A159&lib%5B4%5D=state%3A175"
+    ],
+    [
+      "20210106080824",
+      "https://heinonline.org/HOL/Index?collection=stair&set_as_cursor=clear"
+    ],
+    [
+      "20201111083106",
+      "https://foursquare.com/user/81072002"
+    ],
+    [
+      "20210417075845",
+      "https://mbda.commerce.gov/NewsRoom/PressReleases_FactSheets/DOC/OS/NewsRoom/PressReleases_FactSheets/Services/Services/index.html"
+    ],
+    [
+      "20201019030214",
+      "https://www.pioneercenter.com/Online/error.asp"
+    ],
+    [
+      "20201118214329",
+      "https://www.xcm.org/XCMWebSite/Content/jQuery/css/Content/bootstrap/js/Content/daterangepicker/Content/pixie/css/Scripts/Directives/Content/Openlayers/V4/Content/bootstrap/js/Content/pixie/css/Content/CodeMirror/js/xml-fold.js"
+    ],
+    [
+      "20201223114500",
+      "http://www.sansabatexas.com/calendar/action~oneday/exact_date~1604988000/cat_ids~281,325,283,271/request_format~html/"
+    ],
+    [
+      "20201101124216",
+      "https://www.tigard-or.gov/police/chief.php/feedback/completestreets/programs/index.php"
+    ],
+    [
+      "20201120134151",
+      "https://spyflight.co.uk/404/index.php"
+    ],
+    [
+      "20210429005203",
+      "https://nifa.usda.gov/grant-search/field_who_is_eligible_to_apply/profit-organizations-other-small-businesses-10/field_who_is_eligible_to_apply/1994-land-grant-institutions-2/field_special_notation/434/field_special_notation/399"
+    ],
+    [
+      "20201109181337",
+      "https://www.loc.gov/websites/?fa=contributor:kosovo+%28republic%29%7Csubject:criminal+justice,+administration+of"
+    ],
+    [
+      "20201215090525",
+      "https://permits.cityofirvine.org/irvinepermits/Default.asp"
+    ],
+    [
+      "20210329183536",
+      "https://developer.uspto.gov/data?f%5B0%5D=product_category%3A39180&f%5B1%5D=product_category%3A39198&f%5B2%5D=product_category%3A39203&f%5B3%5D=product_category%3A39213&f%5B4%5D=published_datasets%3A39202"
+    ],
+    [
+      "20201009223700",
+      "https://api.transparency.treasury.gov/lib/fonts/images/lib/firCentral/images/lib/firCentral/assets/reports/fir-api-explorer/assets/reports/fir-rcm/assets/reports/fir-rcm/lib/angular-bind-html-compile/angular-bind-html-compile.js"
+    ],
+    [
+      "20201021104607",
+      "https://collections.nlm.nih.gov/?f%5bdrep2.isMemberOfCollection%5d%5b%5d=DREPIHM"
+    ],
+    [
+      "20201206041213",
+      "https://www.drought.gov/drought/search/event?f%5B0%5D=field_region%3A76&f%5B1%5D=field_region%3A74&f%5B2%5D=field_states%3A84&f%5B3%5D=field_region%3A75&f%5B4%5D=field_states%3A90&f%5B5%5D=field_states%3A95&f%5B6%5D=field_states%3A120&f%5B7%5D=field_states%3A97"
+    ],
+    [
+      "20210325203035",
+      "https://nesr.usda.gov/search?query=&f%5B0%5D=topic%3A77&f%5B1%5D=topic%3A490"
+    ],
+    [
+      "20201209002709",
+      "https://developer.epa.gov/"
+    ],
+    [
+      "20210430074401",
+      "https://www.fas.usda.gov/data/search?f%5B0%5D=field_countries%3A379&f%5B1%5D=field_commodities%3A34&f%5B2%5D=field_countries%3A410&f%5B3%5D=field_countries%3A399"
+    ],
+    [
+      "20210110074557",
+      "http://www.lakeelmo.org/government/government/residents/parks/government/residents/public_notices.php"
+    ],
+    [
+      "20210115231217",
+      "https://www.asheboronc.gov/government/departments/planning___zoning/government/records_retention/_assets_/plugins/bootstrap/css/sunset_theatre/how_do_i/_assets_/fonts/font-awesome/css/font-awesome.min.css"
+    ],
+    [
+      "20210425054512",
+      "https://oceancolor.gsfc.nasa.gov/cgi/browse.pl?per=MO&day=2435&sub=level3&prm=CHL&set=10&ndx=0&mon=2160&sen=cz&rad=0&frc=0&dnm=D@M"
+    ],
+    [
+      "20201106023919",
+      "https://www.shopmyexchange.com/browse/baby-toys/_/N-4294812204+2193263988+103179"
+    ],
+    [
+      "20210418130301",
+      "https://www.omao.noaa.gov/topic/general/equipment?qt-qt_global_articles=0&qt-qt_global_images=4"
+    ],
+    [
+      "20210327111737",
+      "https://www.nwcouncil.org/news?f[0]=field_tags:131&f[1]=field_tags:105&f[2]=field_author:3821"
+    ],
+    [
+      "20210506232717",
+      "https://catalog.data.gov/dataset?tags=alaska&bureauCode=019%3A20&tags=geologic-atlas"
+    ],
+    [
+      "20201122092621",
+      "https://donate.seedmoney.org/embed/card-view/app/bower_components/moment/min/app/bower_components/ng-file-upload/app/bower_components/ng-clip-master/dest/app/bower_components/angular-froala/src/scripts/controllers/HomeCtrl.bd7e5ac9.js"
+    ],
+    [
+      "20201210070257",
+      "https://www.oxfordnc.org/community/economic_development/departments/departments/public_works/departments/parks___recreation/government/other_city_boards_and_commissions.php"
+    ],
+    [
+      "20210119093327",
+      "https://www.asheboronc.gov/government/government/departments/planning___zoning/government/boards_and_commissions/_assets_/plugins/bootstrap/js/businesses/_assets_/fonts/font-awesome/css/font-awesome.min.css"
+    ],
+    [
+      "20201110062007",
+      "https://foursquare.com/v/muzeul-civiliza%C8%9Biei-populare-tradi%C8%9Bionale-astra/4c4ae38cc8b6b71320542efb"
+    ],
+    [
+      "20201103133355",
+      "https://e4ftl01.cr.usgs.gov/MOTA/MCD43D33.006/2007.02.18/"
+    ],
+    [
+      "20201108042116",
+      "http://www.pcsheriff.org/'covid19.nj.gov'"
+    ],
+    [
+      "20201221002909",
+      "https://www.redcross.org/store/preparedness/emergency-supplies/emergency-radio-weather-radio?prefn1=IsCourse&prefv1=false&prefn2=color&prefv2=Smoke%20%24%24%2348474D%7CWhite%20%24%24%23FFFFFF%7CSteel%20Grey%20%24%24%23848484%7CArmy%20Green%20%24%24%235DBCD2&prefn3=isDistributor&prefv3=false"
+    ],
+    [
+      "20201106184631",
+      "https://www.tennille-ga.gov/departments/planning_and_zoning/_assets_/plugins/bootstrap/css/_assets_/js/officials/city_council/February%203%202020.pdf"
+    ],
+    [
+      "20201231081254",
+      "https://www.fs.usda.gov/treesearch/search?keywords=%22forest%20management%22&f%5B0%5D=author_facet%3A%22Lambert%2C%20Samuel%22"
+    ],
+    [
+      "20201012161113",
+      "https://gateway.womenshealth.gov/bower_components/file-saver/app/vendor/leaflet-image/bower_components/angular-sanitize/app/css/bower_components/angular-aria/app/components/app/modules/search/search.service.js"
+    ],
+    [
+      "20201010022339",
+      "https://disc.sci.gsfc.nasa.gov/fonts/bootstrap/scripts/css/lib/MathJax/lib/MathJax/scripts/scripts/lib/MathJax/css/scripts/css/css/scripts/scripts/app.js"
+    ],
+    [
+      "20210104054831",
+      "https://www.arcadiaca.gov/enrich/arcadia_public_library/general_information/whats_new_at_the_library.php/_assets_/plugins/ytplayer/discover/city_manager_s_office/discover/city_council/enrich/recreation___community_services/teen_programs/shape/public_works_services_department/water___sewer_services/_assets_/images/contact-1.png"
+    ],
+    [
+      "20210527183947",
+      "https://www.ecfr.gov/cgi-bin/text-idx?SID=488e712fd8066ecfe1f0ceb612fd564a&mc=true&node=se42.4.431_1200&rgn=div8"
+    ],
+    [
+      "20210104163824",
+      "https://www.millikenco.gov/government/town_board_of_trustees/town_services/parks_and_lakes/alert_signup/business/business/_assets_/images/favicon.ico"
+    ],
+    [
+      "20210102002617",
+      "http://townofcopake.org/calendar/action~oneday/exact_date~1605243600/cat_ids~21,16,37,44,36/request_format~html/"
+    ],
+    [
+      "20210326103953",
+      "https://2014-2017.commerce.gov/sites/commerce.gov/files/adaptivetheme/doc_theme_files/sites/all/themes/doc/doc_theme/scripts/media/photo/sites/commerce.gov/files/styles/scalecrop_100x100/public/spp_page_roundtable_discussion_with_ges_delegates.jpg"
+    ],
+    [
+      "20201017000911",
+      "https://villageflowerhill.org/mayor-herrington-addresses-st-francis-hospital-expansion-plans-for-oaktree-lane/"
+    ],
+    [
+      "20210514074925",
+      "https://forecast.weather.gov/product.php?site=BRO&product=CF6&issuedby=WAL"
+    ]
+  ]
+}

--- a/webcomponent/samples/MC.summary.json
+++ b/webcomponent/samples/MC.summary.json
@@ -1,0 +1,661 @@
+{
+  "captures": 3221758919,
+  "urls": 2381208479,
+  "hosts": 5366007,
+  "bytes": 172013736891324,
+  "first": "20160609215144",
+  "last": "20220202144009",
+  "tophosts": {
+    "wp.me": 11457705,
+    "upload.wikimedia.org": 10667921,
+    "designtaxi.com": 10639524,
+    "indiewire.com": 10341593,
+    "public-api.wordpress.com": 9176593,
+    "youtube.com": 7301589,
+    "facebook.com": 6414589,
+    "elfagr.com": 6122678,
+    "secure.gravatar.com": 6095165,
+    "googletagmanager.com": 5627624,
+    "sn.dk": 5316419,
+    "robesonian.com": 4972124,
+    "haberler.com": 4911462,
+    "youm7.com": 4735164,
+    "bn.wikipedia.org": 4500460,
+    "pbs.twimg.com": 4494328,
+    "r-login.wordpress.com": 4398652,
+    "usatoday.com": 4383796,
+    "bhaskar.com": 4299731,
+    "id.wikipedia.org": 4231815
+  },
+  "mimestatus": {
+    "HTML": {
+      "2XX": 965411367,
+      "3XX": 276575748,
+      "4XX": 125142922,
+      "5XX": 10774370,
+      "Other": 254055
+    },
+    "Image": {
+      "2XX": 595129981,
+      "3XX": 1848252,
+      "4XX": 1176862,
+      "5XX": 110163,
+      "Other": 6
+    },
+    "CSS": {
+      "2XX": 34916375,
+      "3XX": 7815,
+      "4XX": 35193,
+      "5XX": 658,
+      "Other": 0
+    },
+    "JavaScript": {
+      "2XX": 54437714,
+      "3XX": 14160,
+      "4XX": 139220,
+      "5XX": 1478,
+      "Other": 3
+    },
+    "JSON": {
+      "2XX": 72073766,
+      "3XX": 378508,
+      "4XX": 6435865,
+      "5XX": 182669,
+      "Other": 0
+    },
+    "XML": {
+      "2XX": 123611319,
+      "3XX": 474681,
+      "4XX": 8382386,
+      "5XX": 265499,
+      "Other": 0
+    },
+    "Text": {
+      "2XX": 9717016,
+      "3XX": 4989191,
+      "4XX": 5825931,
+      "5XX": 89757,
+      "Other": 7
+    },
+    "PDF": {
+      "2XX": 907503,
+      "3XX": 1743,
+      "4XX": 297,
+      "5XX": 12,
+      "Other": 0
+    },
+    "Font": {
+      "2XX": 1348879,
+      "3XX": 208,
+      "4XX": 5827,
+      "5XX": 21,
+      "Other": 0
+    },
+    "Audio": {
+      "2XX": 1655064,
+      "3XX": 7847,
+      "4XX": 4701,
+      "5XX": 9,
+      "Other": 0
+    },
+    "Video": {
+      "2XX": 2081368,
+      "3XX": 14928,
+      "4XX": 20936,
+      "5XX": 5,
+      "Other": 0
+    },
+    "Revisit": {
+      "2XX": 0,
+      "3XX": 0,
+      "4XX": 0,
+      "5XX": 0,
+      "Other": 790098238
+    },
+    "Other": {
+      "2XX": 34327496,
+      "3XX": 87943703,
+      "4XX": 4302731,
+      "5XX": 629212,
+      "Other": 5254
+    }
+  },
+  "pathquery": {
+    "P0": {
+      "Q0": 10137110,
+      "Q1": 75096506,
+      "Q2": 5222175,
+      "Q3": 1422227,
+      "Q4": 736628,
+      "Other": 2345905
+    },
+    "P1": {
+      "Q0": 322542556,
+      "Q1": 43841147,
+      "Q2": 27014507,
+      "Q3": 29103774,
+      "Q4": 7100402,
+      "Other": 41134623
+    },
+    "P2": {
+      "Q0": 370206924,
+      "Q1": 55247724,
+      "Q2": 28783611,
+      "Q3": 31029789,
+      "Q4": 9766427,
+      "Other": 26319078
+    },
+    "P3": {
+      "Q0": 367658614,
+      "Q1": 61591011,
+      "Q2": 17508660,
+      "Q3": 15919708,
+      "Q4": 5806691,
+      "Other": 13254728
+    },
+    "P4": {
+      "Q0": 310543626,
+      "Q1": 140279203,
+      "Q2": 80114245,
+      "Q3": 7705491,
+      "Q4": 2250744,
+      "Other": 6257513
+    },
+    "Other": {
+      "Q0": 881020001,
+      "Q1": 157916352,
+      "Q2": 26846263,
+      "Q3": 18521368,
+      "Q4": 6848796,
+      "Other": 14664792
+    }
+  },
+  "yearmonth": {
+    "2016": {
+      "01": 0,
+      "02": 0,
+      "03": 0,
+      "04": 0,
+      "05": 0,
+      "06": 710753,
+      "07": 0,
+      "08": 0,
+      "09": 0,
+      "10": 0,
+      "11": 0,
+      "12": 0
+    },
+    "2018": {
+      "01": 0,
+      "02": 0,
+      "03": 0,
+      "04": 0,
+      "05": 18409894,
+      "06": 20138119,
+      "07": 63997290,
+      "08": 82864370,
+      "09": 101464239,
+      "10": 52569004,
+      "11": 170693250,
+      "12": 112690671
+    },
+    "2019": {
+      "01": 19598526,
+      "02": 162402131,
+      "03": 65102242,
+      "04": 88210019,
+      "05": 10937609,
+      "06": 79065196,
+      "07": 83674051,
+      "08": 33172213,
+      "09": 78516813,
+      "10": 87399023,
+      "11": 73646742,
+      "12": 84030203
+    },
+    "2020": {
+      "01": 80033841,
+      "02": 76467578,
+      "03": 84829936,
+      "04": 176568383,
+      "05": 195626716,
+      "06": 227839303,
+      "07": 55837610,
+      "08": 48706314,
+      "09": 44075057,
+      "10": 43451655,
+      "11": 62242880,
+      "12": 58438537
+    },
+    "2021": {
+      "01": 56130245,
+      "02": 38882332,
+      "03": 55665115,
+      "04": 45999374,
+      "05": 45209593,
+      "06": 43396066,
+      "07": 46897574,
+      "08": 45611165,
+      "09": 20527175,
+      "10": 45615260,
+      "11": 42424841,
+      "12": 50262197
+    },
+    "2022": {
+      "01": 40104802,
+      "02": 1623012,
+      "03": 0,
+      "04": 0,
+      "05": 0,
+      "06": 0,
+      "07": 0,
+      "08": 0,
+      "09": 0,
+      "10": 0,
+      "11": 0,
+      "12": 0
+    }
+  },
+  "samples": [
+    [
+      "20200527210816",
+      "https://mansion-san-miguel-san-miguel-de-allende.booked.se//amp.html"
+    ],
+    [
+      "20190330160914",
+      "http://nna-leb.gov.lb/fr/show-news/101744/nna-leb.gov.lb/nna-leb.gov.lb"
+    ],
+    [
+      "20190608121808",
+      "https://finance.yahoo.com/news/mad-crypto-look-behind-coinbase-140701811.html"
+    ],
+    [
+      "20200429135903",
+      "https://mcuoneclipse.com/2017/07/09/karwendel/"
+    ],
+    [
+      "20190706201030",
+      "https://www.elheraldo.hn/pais/1299190-466/anuncian-fumigaciones-nocturnas-para-frenar-zancudo-aedes-aegypti-en-honduras"
+    ],
+    [
+      "20200822195952",
+      "https://informer.rs/tv-in/vesti/530165/doktorka-darija-otkrila-nosenje-maske-smanjuje-verovatnocu-zaraze-ispod-jedan-odsto"
+    ],
+    [
+      "20191022061138",
+      "https://www.patrika.com/banswara-news/children-of-gutka-tobacco-eating-women-become-malnourished-5203171/"
+    ],
+    [
+      "20200326162803",
+      "https://www.haaretz.com/food/.premium.MAGAZINE-yes-you-can-and-should-appreciate-canned-food-1.8710319"
+    ],
+    [
+      "20200529190909",
+      "http://www.viralnewslatest.com/2020/01/"
+    ],
+    [
+      "20190331133315",
+      "https://www.ilcittadinodirecanati.it/notizie-recanati/46430-cinquanta-giorni-per-abbattere-la-ex-gigli-e-smaltire-macerie"
+    ],
+    [
+      "20200117223439",
+      "https://www.usatoday.com/story/sports/nfl/2015/03/12/jury-nfl-breached-super-bowl-tickets-contract-but-no-fraud/70230932/"
+    ],
+    [
+      "20191204161510",
+      "https://www.googletagmanager.com/ns.html?id=GTM-PNPR354&tncms.template.version=3.152.0&tncms.page.grid=defender&tncms.page.style=default&tncms.page.path=%2Fnews&tncms.page.syndicated=false&tncms.page.reaction=false&tncms.page.app=editorial&tncms.page.theme=flex&tncms.page.skin=flex-editorial&tncms.page.http_status=200&tncms.subscription.required=false&tncms.asset.author=FOX+12+Staff&tncms.vendor.outbrain=Headlines+and+photo+grid&tncms.vendor.taboola=&tncms.vendor.chartbeat=19747&tncms.vendor.comscore=6036305&tncms.system.render_time=235&tncms.client.is_bot=yes&tncms.client.is_gdpr=no&tncms.client.noscript=yes"
+    ],
+    [
+      "20210609022051",
+      "https://www.towleroad.com/2020/09/canadas-drag-race-queen/"
+    ],
+    [
+      "20200208194619",
+      "https://www.dailynews.com/2020/02/07/councilman-explores-safe-parking-site-in-former-sherman-oaks-homeless-encampment/amp/"
+    ],
+    [
+      "20181201144814",
+      "https://amp.24h.com.vn/doi-song-showbiz/con-trai-chuc-mung-sinh-nhat-bo-dan-truong-qua-tuoi-42-cuc-dang-yeu-c729a1009561.html"
+    ],
+    [
+      "20191023154117",
+      "https://www.usnews.com/news/world/articles/2019-10-22/malaysian-prosecutor-najib-orchestrated-graft-like-an-emperor"
+    ],
+    [
+      "20200223201637",
+      "https://www.winghamchronicle.com.au/story/6641097/helpers-are-key/?src=rss"
+    ],
+    [
+      "20200811141734",
+      "https://www.texemarrs.com/062017/putin_defends_christian_civilization.htm"
+    ],
+    [
+      "20210604085006",
+      "http://internationalfilmstudies.blogspot.com/2018/06/hannah-arendt-germanyluxemborgfrance.html"
+    ],
+    [
+      "20190713153207",
+      "https://www.elsoldeleon.com.mx/policiaca/presuntos-ladrones-abandonan-botin-en-bulevar-vicente-valtierra-3891706.html"
+    ],
+    [
+      "20210716072315",
+      "https://www.emirates.com/us/english/destinations/flights-from-entebbe.aspx"
+    ],
+    [
+      "20200613145639",
+      "http://connect.mail.ru/login?connect=1&page=http%3a%2f%2fconnect.mail.ru%2fshare%3fshare_url%3dhttps%253A%252F%252Fadigea.aif.ru%252Fsociety%252Fdetails%252Fprodolzhaetsya_dekada_lgotnoy_podpiski_na_gazetu_aif%2dadygeya"
+    ],
+    [
+      "20200319012135",
+      "https://pantip.com/topic/39724025"
+    ],
+    [
+      "20200630033523",
+      "https://wartakota.tribunnews.com/tag/benny-likumahuwa?url=2020/06/10/bangga-menjadi-anak-benny-likumahuwa-barry-likumahuwa-papa-sangat-jenius-dalam-bermusik"
+    ],
+    [
+      "20190204064248",
+      "https://www.kentlive.news/news/kent-news/man-arrested-after-disturbance-bower-2472479.amp"
+    ],
+    [
+      "20190913193850",
+      "http://www.thailand4.com/.evnt/2019-08-14/2b565f14e4ab99136eb8d2bae4fb8c0f/"
+    ],
+    [
+      "20190301140437",
+      "http://www.meridiano.com.ve/futbol/premier-league/190388/tottenham-sigue-sin-empatar-en-la-premier.html"
+    ],
+    [
+      "20181205141713",
+      "https://www3.smartadserver.com/ac?out=nonrich&nwid=1517&siteid=79798&pgname=hp&fmtid=34509&visit=m&tmstp=1544014186"
+    ],
+    [
+      "20200312232938",
+      "https://www.albawabhnews.com/service/nc.aspx?id=3934368"
+    ],
+    [
+      "20190914094921",
+      "https://www.todayonline.com/content/tagreuterscom2019newsmllynxnpef8403p"
+    ],
+    [
+      "20190925024635",
+      "https://m.sify.com/finance/court-rejects-bid-to-put-blixseth-into-bankruptcy-news-international-nhlhameihbjsi.html"
+    ],
+    [
+      "20200423072836",
+      "https://www.mischianti.org/2019/08/"
+    ],
+    [
+      "20210428003406",
+      "https://sr.wikipedia.org/wiki/%D0%9D%D0%B0%D0%B3%D1%80%D0%B0%D0%B4%D0%B0_%D0%A1%D0%BF%D0%B8%D1%80%D0%B8%D1%82_%D0%B7%D0%B0_%D0%BD%D0%B0%D1%98%D0%B1%D0%BE%D1%99%D0%B8_%D1%84%D0%B8%D0%BB%D0%BC"
+    ],
+    [
+      "20200527035813",
+      "https://icons8.com.br/ouch/search/%EC%A0%84%EC%A3%BC%EC%98%A4%ED%94%BC%E3%80%90www.op600.com%E3%80%91%EB%8B%AC%EC%BD%A4%EC%84%B9%EC%8B%9C%E5%9C%89%EC%A0%84%EC%A3%BC%EC%95%88%EB%A7%88%E3%88%B7%EC%A0%84%EC%A3%BC%EC%98%A4%ED%94%BC%E1%94%AA%EC%A0%84%EC%A3%BCkiss%E1%94%AE%EC%A0%84%EC%A3%BC%ED%92%80%EC%8B%B8%EB%A1%B1%E1%94%9D%EC%A0%84%EC%A3%BC%EC%98%A4%ED%94%BC%E1%91%8E%EC%A0%84%EC%A3%BC%EC%98%A4%ED%94%BC%E1%93%95%EC%A0%84%EC%A3%BC%ED%82%A4%EC%8A%A4%EB%B0%A9/"
+    ],
+    [
+      "20210518185554",
+      "https://ca.hellomagazine.com/fashion/celebrity-style/gallery/2020042588527/amanda-holden-best-britains-got-talent-outfits-photos/1/"
+    ],
+    [
+      "20181107032721",
+      "https://www.eleftheriaonline.gr/local/oikonomia/ypodomes/item/168854-to-noemvrio-i-meleti-gia-to-kalamata-rizomylos/amp"
+    ],
+    [
+      "20181209134830",
+      "http://www.bdlive.co.za/business/energy/2014/10/15/energy-funds-irregular-spending-soars"
+    ],
+    [
+      "20181102214141",
+      "http://www.lavoixdunord.fr/467097/article/2018-10-11/comportements-violents-au-ch-dron-un-jour-il-y-aura-un-drame-c-est-sur?noCookies=1"
+    ],
+    [
+      "20201102192928",
+      "https://www.grizzlybearblues.com/2020/6/4/21279941/game-preview-grizz-gaming-looking-for-third-win-nba2k-esports"
+    ],
+    [
+      "20190303185633",
+      "https://www.elcordillerano.com.ar/amp/noticias/2019/02/26/76151-impresionante-choque-sin-heridos-sobre-diagonal-capraro"
+    ],
+    [
+      "20210705095335",
+      "https://collingswood.umcommunities.org/events/"
+    ],
+    [
+      "20220104124729",
+      "https://marvamedia.wufoo.com/embed/z9zjza1mpvn62/"
+    ],
+    [
+      "20191214185722",
+      "https://avaz.ba/showbiz/jet-set/534743/holivudska-zvijezda-provozala-traktor-na-svojoj-farmi-i-odusevila-sve?amp=1"
+    ],
+    [
+      "20200429152042",
+      "https://www.googletagmanager.com/ns.html?id=GTM-PFPF5KK&pageType=Artikel&pageUrl=https:%5C/%5C/www.harzkurier.de%5C/niedersachsen%5C/article228723317%5C/Wolfenbuettel-Stadt-und-Kreisverwaltung-fuer-Besucher-zu.html&pageCategory=Niedersachsen&pageCategory02=&pageCategory03=&sectionId=14265&sectionId02=&sectionId03=&pageAGOF-IVW=bzv-hk-niedersachsen-art&pageAsmi=%5C/(nachrichten_story)&isLoggedIn=&pageArticleID=228723317&pageContentType=Nachricht&pageSourcePublication=bzv-wz&pageTitle=Wolfenb%5Cu00FCttel:%20Stadt-%20und%20Kreisverwaltung%20f%5Cu00FCr%20Besucher%20zu&pageTitleOriginal=Wolfenb%5Cu00FCttel:%20Stadt-%20und%20Kreisverwaltung%20f%5Cu00FCr%20Besucher%20zu&pageDescription=Die%20Wolfenb%5Cu00FCtteler%20Stadtverwaltung%20und%20die%20Kreisverwaltung%20schlie%5Cu00DFen%20komplett%20f%5Cu00FCr%20den%20Besuchsverkehr.%20Die%20B%5Cu00FCrger%20sollen%20sich%20telefonisch%20melden.&pageKeywords=&pageHashtags=&pageTags=Stadt,%20Kontakt,%20Verwaltung,%20Verwaltung,%20Post,%20Internet,%20Besucher,%20Telefon,%20Internet,%20Wolfenb%5Cu00FCttel,%20Kita,%20Kommunen,%20Landkreis,%20Dienstleistungen,%20Donnerstag,%20April,%20Ma%5Cu00DFnahmen,%20Standesamt,%20M%5Cu00E4rz,%20April&pagePublished=2020-03-18%2017:00:00&pageModified=2020-04-03%2014:12:26&pageDate=2020-03-18&pageDay=18&pageMonth=03&pageYear=2020&pageAuthor=Maria%20Osburg&pageSource=meth01b&isPaidContent=false&pageLengthWords=394&pagePictures=1&pageVideos=0&pageFirstClickFree=false&pagePrio=4%20-%20Normal"
+    ],
+    [
+      "20211116112557",
+      "https://www.urbanet.info/streets-cape-town/"
+    ],
+    [
+      "20200317202552",
+      "https://securepubads.g.doubleclick.net/gampad/adx?iu=/32805352/VA-Norfolk-WVEC-B3346_DesktopTablet/article_flex_btf/news/health/coronavirus&sz=970x250|728x90|1140x286|1x1&c=204"
+    ],
+    [
+      "20200630035334",
+      "https://nsjonline.com/article/2020/06/in-time-of-crises-lands-bill-gives-senate-a-chance-to-unite/"
+    ],
+    [
+      "20210813231741",
+      "https://www.calcionapoli24.it/le_interviste/malfitano-callejon-ha-la-testa-altrove-non-sarebbe-una-grave-perdita-n446733.html"
+    ],
+    [
+      "20201209190829",
+      "https://www.ellitoral.com.ar/corrientes/2020-7-19-13-50-0-festejo-musical-por-el-dia-del-amigo-con-grandes-figuras"
+    ],
+    [
+      "20200228101627",
+      "https://www.isna.ir/news/98120705559/%D8%A2%D8%A8%DA%AF%D8%B1%D9%81%D8%AA%DA%AF%DB%8C-%DB%8C%DA%A9-%D8%B1%D9%88%D8%B3%D8%AA%D8%A7-%D8%AF%D8%B1-%D8%B4%D9%88%D8%B4%D8%AA%D8%B1-%D8%B1%DB%8C%D8%B2%D8%B4-%D8%A2%D9%88%D8%A7%D8%B1-%DB%8C%DA%A9-%D9%85%D9%86%D8%B2%D9%84-%D8%AF%D8%B1-%D8%AF%D8%B2%D9%81%D9%88%D9%84"
+    ],
+    [
+      "20200319124726",
+      "https://www.eltiempo.com/cultura/arte-y-teatro/obra-vida-de-carolina-gaitan-en-el-teatro-nacional-390056"
+    ],
+    [
+      "20200826235748",
+      "https://fr.tripadvisor.ch/Attractions-g297478-Activities-c47-t7-Medellin_Antioquia_Department.html"
+    ],
+    [
+      "20200121053111",
+      "https://www.poconorecord.com/article/20150729/NEWS/150729385"
+    ],
+    [
+      "20181009194523",
+      "https://tw.news.yahoo.com/amphtml/%E8%8F%AF%E7%82%BAmate20%E8%AB%9C%E7%85%A7%E6%9B%9D%E5%85%89-%E5%B0%B1%E6%98%AF%E9%80%99%E6%A8%A3-080523792.html"
+    ],
+    [
+      "20200118192927",
+      "https://vm.ru/news/774993-predstavitel-zhvaneckogo-prokommentiroval-sluhi-o-strashnoj-bolezni/amp"
+    ],
+    [
+      "20200607204252",
+      "https://www.diariopuntual.com/node/40007"
+    ],
+    [
+      "20200503095644",
+      "https://www.rts.rs/page/stories/ci/story/2/svet/3927008/nemacka-drzavljanstvo-pasos.html"
+    ],
+    [
+      "20200420201003",
+      "https://thebestfetishsites.com/it/top-bdsm-sites/bdsmstreak/"
+    ],
+    [
+      "20200428100435",
+      "http://www.laopinionpuebla.com/ejecutan-a-hombre-en-acatzingo-2/assets/plugins/tinymce/assets/dist/css/main.css"
+    ],
+    [
+      "20190210163235",
+      "https://www.standard.co.uk/news/uk/woman-who-died-on-train-may-have-hit-head-while-leaning-out-of-window-a4006281.html?amp"
+    ],
+    [
+      "20200616034412",
+      "https://okwave.jp/amp/qa/q388029.html"
+    ],
+    [
+      "20220103002118",
+      "https://www.diarioahora.pe/tag/cc-vulnerables/"
+    ],
+    [
+      "20200428080046",
+      "https://es.player.fm/series/women-in-archaeology-2323631/gbac-2018-recap"
+    ],
+    [
+      "20191004194429",
+      "https://news.mynavi.jp/article/20190930-901554:amp/"
+    ],
+    [
+      "20200922204759",
+      "https://ko.wikipedia.org/wiki/%EB%A7%88%EA%B7%B8%EB%84%A4%ED%83%80"
+    ],
+    [
+      "20181011115314",
+      "https://www.jagran.com/business/biz-state-bank-of-india-reports-1329-fraud-cases-worth-rupees-5555-crore-18518792.html"
+    ],
+    [
+      "20200311154013",
+      "https://www.20minutos.es/noticia/4181615/0/noemi-salazar-de-gh-vip-muestra-los-retoques-esteticos-realizados-en-su-cara/"
+    ],
+    [
+      "20200627050735",
+      "https://www.sttinfo.fi/tiedote/lampaat-aloittivat-kesatyot?publisherId=67975446&releaseId=69881092"
+    ],
+    [
+      "20190703175603",
+      "https://www.consilium.europa.eu/mt/policies/sanctions/ukraine-crisis/?utm_source=dsms-auto&utm_medium=email&utm_campaign=Rechtswidrige+Annexion+der+Krim+und+Sewastopols:+EU+verl%C3%A4ngert+Sanktionen+um+ein+Jahr"
+    ],
+    [
+      "20190914005826",
+      "https://www.lavanguardia.com/opinion/20190820/464173946889/un-esfuerzo-conjunto-por-la-seguridad.html"
+    ],
+    [
+      "20200214155639",
+      "https://indianexpress.com/article/business/performance-under-vivad-se-vishwas-scheme-to-be-an-important-factor-for-postings-of-i-t-officers6267216/"
+    ],
+    [
+      "20200625205747",
+      "https://scholar.google.com/scholar_lookup?title=Evolving%20genes%20and%20proteins&author=Zuckerkandl%20E&publication_year=1965"
+    ],
+    [
+      "20190203113001",
+      "http://reporternews.com.br/noticia/429921/Terrorista_esteve_em_Sinop__Lucas_e_Caceres__diz_imprensa_italiana"
+    ],
+    [
+      "20190608005537",
+      "https://www.beaumontenterprise.com/news/us/article/The-Latest-Trump-declares-major-disaster-in-13917223.php"
+    ],
+    [
+      "20200214185427",
+      "https://lampung.tribunnews.com/amp/2020/02/13/musnahkan-knalpot-racing-hasil-razia-kasatlantas-sebut-boleh-modifikasi-kendaraan-asalkan"
+    ],
+    [
+      "20220105011456",
+      "https://justbutik.ru/catalog/abbot-kinney?subid_ref=brands"
+    ],
+    [
+      "20190426030617",
+      "https://www.nwfdailynews.com/news/20171101/crestview-teen-accused-of-stealing-car-may-be-connected-to-shooting"
+    ],
+    [
+      "20190913202631",
+      "http://www.jujuyalmomento.com/post/105426/envian-ternas-para-cinco-cargos-en-la-justicia.html"
+    ],
+    [
+      "20211104122726",
+      "https://www.cinephiled.com/genre/kino-lorber/"
+    ],
+    [
+      "20190203000452",
+      "http://thvl.vn/?p=519774"
+    ],
+    [
+      "20200110150453",
+      "https://sports.walla.co.il/item/3334167"
+    ],
+    [
+      "20180521143455",
+      "http://uzmanpara.milliyet.com.tr/haber-detay/gundem2/euro-bolgesinde-enflasyon-geriledi/82000/82578/"
+    ],
+    [
+      "20180923124732",
+      "https://in.news.yahoo.com/amphtml/planning-public-sector-diversity-162330032.html"
+    ],
+    [
+      "20210113200026",
+      "https://www.pronto.com.ar/articulo/famosos/conmovedor-mensaje-despedida-lizy-tagliani-floppy/20200728081424367663.html"
+    ],
+    [
+      "20191005075806",
+      "https://news.sina.com.tw/article/20190906/32577062.html"
+    ],
+    [
+      "20190716211901",
+      "https://www.elsoldepuebla.com.mx/finanzas/el-matematico-britanico-alan-turing-aparecera-en-nuevos-billetes-de-50-libras-3902406.html/amp"
+    ],
+    [
+      "20190402160717",
+      "http://www.nordestealdia.com/formosa/notix/noticia/76224/0000/inc.widget_video_aen.php"
+    ],
+    [
+      "20200712023529",
+      "https://epoca.globo.com/mundo/lockdown-na-india-como-quarentena-matou-mais-de-300-pessoas-que-nao-tinham-coronavirus-24464310?versao=amp"
+    ],
+    [
+      "20181122172025",
+      "https://www.chinatimes.com/newspapers/20181027000718-260102"
+    ],
+    [
+      "20190706162718",
+      "https://indiankanoon.org/doc/160675123/"
+    ],
+    [
+      "20200121141831",
+      "http://desciclopedia.ws/index.php?title=Annora_Petrova&diff=3706689&oldid=3650655"
+    ],
+    [
+      "20180723110226",
+      "https://amprensa.com/2018/07/estos-fueron-los-cambios-de-diego-boneta-para-parecerse-a-luis-miguel-en-la-serie/"
+    ],
+    [
+      "20181006165935",
+      "https://www.berria.eus/albisteak/105789/demokrazia_prozesu_dinamikotzat_jo_eta_erabakitzeko_eskubidea_babestu_du_gibernauk.htm"
+    ],
+    [
+      "20200113053745",
+      "https://1k.com.ua/aviakompaniya-budet-pokazyvat-matchi-dota-2-vo-vremya-polyotov-chempionat.html/amp"
+    ],
+    [
+      "20181213163748",
+      "https://tamil.oneindia.com/amphtml/news/tamilnadu/tn-govt-conduct-tet-exam-mk-stalin-257455.html"
+    ],
+    [
+      "20180914121145",
+      "https://www.regio7.cat/bages/2018/09/13/lajuntament-sallent-vol-inscriure-campanar/497591.html"
+    ],
+    [
+      "20200111162315",
+      "https://diariolavoz.net/2019/12/16/docente-peruano-abuso-de-una-alumna-venezolana-de-13-anos/"
+    ],
+    [
+      "20200527205826",
+      "https://www.usatoday.com/border-wall/documentaries/dist/lib/angular/lib/bootstrap/dist/css/lib/angular/lib/angular-cookies/lib/moment/lib/jquery/dist/jquery.min.js"
+    ],
+    [
+      "20190623153546",
+      "https://www.modbee.com/sports/article231869813.html"
+    ],
+    [
+      "20180830120114",
+      "http://bartabazar.com/archives/43562"
+    ]
+  ]
+}


### PR DESCRIPTION
* Add sample thumbnails using iframes
* Place sample URIs list in details element to show/hide
* Make the initial display state of the random samples list configurable
* Add path segment and query parameter explanation
* Change section titles
* Change grid to matrix and fix some typos
* Support selection of various number formats (short, percent, local)
* Make playback URL prefix customizable
* Make number of thumbnails customizable
* Add an optional name attribute (using name instead of title to avoid global tooltip)
* Add an optional type attribute to specify if the summary is of an item, collection, or arbitrary CDX files
* Add an optional report URI attribute to link to the detailed report (automatically populate it for Petabox items)
* Enhance the tooltip of numeric cells with various number formats and title
* Add an interactive tester with samples