### PR TITLE
Remove center alignment of tables and thumbs

### DIFF
--- a/webcomponent/cdxsummary.js
+++ b/webcomponent/cdxsummary.js
@@ -289,7 +289,6 @@ ${this.sampleCapturesList()}
     border-collapse: collapse;
     display: block;
     max-width: fit-content;
-    margin: 0 auto;
     overflow-x: auto;
     white-space: nowrap;
   }
@@ -341,9 +340,6 @@ ${this.sampleCapturesList()}
   }
   details.samples:not([open]) summary::after {
     content: attr(data-close);
-  }
-  .sample-thumbs {
-    text-align: center;
   }
   .thumb-container {
     width: 294px;

--- a/webcomponent/package.json
+++ b/webcomponent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/cdxsummary",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A Web Component to render CDX Summary JSON files",
   "main": "cdxsummary.js",
   "module": "cdxsummary.js",


### PR DESCRIPTION
Center alignment of narrow tables may look odd on wide screens.
